### PR TITLE
Use @auto_closure to avoid ugly closures

### DIFF
--- a/swiftz/Either.swift
+++ b/swiftz/Either.swift
@@ -7,8 +7,8 @@
 //
 
 enum Either<L, R> {
-  case Left(() -> L)
-  case Right(() -> R)
+  case Left(@auto_closure () -> L)
+  case Right(@auto_closure () -> R)
 }
 
 // Equatable
@@ -27,13 +27,13 @@ func !=<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Boo
 // 'functions'
 
 func pure<L, R>(a: R) -> Either<L, R> {
-  return .Right({ a })
+  return .Right(a)
 }
 
 func <^><L, RA, RB>(f: RA -> RB, a: Either<L, RA>) -> Either<L, RB> {
   switch a {
   case let .Left(l): return .Left(l)
-  case let .Right(r): return Either<L, RB>.Right({ f(r()) })
+  case let .Right(r): return Either<L, RB>.Right(f(r()))
   }
 }
 
@@ -42,7 +42,7 @@ func <*><L, RA, RB>(f: Either<L, RA -> RB>, a: Either<L, RA>) -> Either<L, RB> {
   case let .Left(l): return .Left(l)
   case let .Right(r): switch f {
   case let .Left(m): return .Left(m)
-  case let .Right(g): return Either<L, RB>.Right({ g()(r()) })
+  case let .Right(g): return Either<L, RB>.Right(g()(r()))
     }
   }
 }

--- a/swiftzTests/DataTests.swift
+++ b/swiftzTests/DataTests.swift
@@ -30,9 +30,9 @@ class DataTests: XCTestCase {
   func testEither() {
     func divTwoEvenly(x: Int) -> Either<String, Int> {
       if x % 2 == 0 {
-        return .Left({ "\(x) was div by 2" })
+        return .Left("\(x) was div by 2")
       } else {
-        return .Right({ x / 2 })
+        return .Right(x / 2)
       }
     }
     
@@ -42,8 +42,8 @@ class DataTests: XCTestCase {
     let first: Either<String, Int> = divTwoEvenly(start)
     let prettyPrinted: Either<String, String> = { $0.description } <^> first
     let snd = first >>= divTwoEvenly
-    XCTAssert(prettyPrinted == .Right({ "8" }))
-    XCTAssert(snd == .Left({ "8 was div by 2" }))
+    XCTAssert(prettyPrinted == .Right("8"))
+    XCTAssert(snd == .Left("8 was div by 2"))
   }
   
   func testResult() {


### PR DESCRIPTION
It seems that `@auto_closure` could be used to avoid closures at the call site. It will simplify further removal of the hack.
