### PR TITLE
Added malloc / free helpers

### DIFF
--- a/swiftz.xcodeproj/project.pbxproj
+++ b/swiftz.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		593CB65C19455ABB00668CD1 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593CB65B19455ABB00668CD1 /* Result.swift */; };
 		593E7389193F16B10071B91D /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593E7388193F16B10071B91D /* Future.swift */; };
 		5951313C19406DA600AB490C /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5951313B19406DA600AB490C /* JSON.swift */; };
+		597AB1461946F81E002DF62D /* Libc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 597AB1451946F81E002DF62D /* Libc.swift */; };
 		59B26545193F365A007AA82B /* GCDExecutionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B26544193F365A007AA82B /* GCDExecutionContext.swift */; };
 		59B2DCBA19434706002ACB3E /* TupleExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B2DCB919434706002ACB3E /* TupleExt.swift */; };
 		59B39E3E1943094F00F4B222 /* Curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B39E3D1943094F00F4B222 /* Curry.swift */; };
@@ -81,6 +82,7 @@
 		593CB65B19455ABB00668CD1 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		593E7388193F16B10071B91D /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Future.swift; sourceTree = "<group>"; };
 		5951313B19406DA600AB490C /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		597AB1451946F81E002DF62D /* Libc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Libc.swift; sourceTree = "<group>"; };
 		59B26544193F365A007AA82B /* GCDExecutionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GCDExecutionContext.swift; sourceTree = "<group>"; };
 		59B2DCB919434706002ACB3E /* TupleExt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TupleExt.swift; sourceTree = "<group>"; };
 		59B39E3D1943094F00F4B222 /* Curry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Curry.swift; sourceTree = "<group>"; };
@@ -141,11 +143,6 @@
 				593C913E193DDC610067F2BE /* Semigroup.swift */,
 				593C913C193DDC060067F2BE /* Monoid.swift */,
 				5951313B19406DA600AB490C /* JSON.swift */,
-				593C9140193DE6AB0067F2BE /* ArrayExt.swift */,
-				590522CB193F5DBA0036614F /* OptionalExt.swift */,
-				5908C1B7194076810024A36C /* DictionaryExt.swift */,
-				5931F2E919407DC600B0526A /* NSArrayExt.swift */,
-				59DB16241940895D00E656F9 /* NSDictionaryExt.swift */,
 				DB76117A19439C8300A0AF82 /* Set.swift */,
 			);
 			name = Data;
@@ -157,6 +154,7 @@
 				5910EA99193DCEE9008F6D71 /* Base.swift */,
 				59B39E3D1943094F00F4B222 /* Curry.swift */,
 				592A122819435308003BF787 /* Lens.swift */,
+				597AB1451946F81E002DF62D /* Libc.swift */,
 			);
 			name = Control;
 			sourceTree = "<group>";
@@ -405,6 +403,7 @@
 				593E7389193F16B10071B91D /* Future.swift in Sources */,
 				593C9141193DE6AC0067F2BE /* ArrayExt.swift in Sources */,
 				593CB65C19455ABB00668CD1 /* Result.swift in Sources */,
+				597AB1461946F81E002DF62D /* Libc.swift in Sources */,
 				590522CC193F5DBA0036614F /* OptionalExt.swift in Sources */,
 				591A21941941D453005FE900 /* Functor.swift in Sources */,
 				590522CE193F61210036614F /* Chan.swift in Sources */,

--- a/swiftz/Libc.swift
+++ b/swiftz/Libc.swift
@@ -1,0 +1,18 @@
+//
+//  Libc.swift
+//  swiftz
+//
+//  Created by Maxwell Swadling on 10/06/2014.
+//  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
+//
+
+import Foundation
+
+// heh, overloading makes this cleaner than haskell...
+func mallocPtr<A>(owner: AnyObject?) -> CMutablePointer<A> {
+  return CMutablePointer(owner: owner, value: malloc(UInt(sizeof(A))).value)
+}
+
+func freePtr<A>(ptr: CMutablePointer<A>) {
+  free(CMutableVoidPointer(owner: nil, value: ptr.value))
+}

--- a/swiftzTests/ControlTests.swift
+++ b/swiftzTests/ControlTests.swift
@@ -91,4 +91,9 @@ class ControlTests: XCTestCase {
     XCTAssert(hostname(party) == "max")
     XCTAssert(hostname(updatedParty) == "Max")
   }
+  
+  func testLibc() {
+    let s: CMutablePointer<String> = mallocPtr(nil)
+    freePtr(s)
+  }
 }


### PR DESCRIPTION
2 helpers for allocating and freeing c structs. This is useful for when a c structs doesn't have a helper function to construct it, such as `pthread`.

I'm not certain if this is correct, feedback welcome :)
