### PR TITLE
Add free sort functions for ImArray.

### DIFF
--- a/swiftz/ImArray.swift
+++ b/swiftz/ImArray.swift
@@ -247,3 +247,10 @@ func >>=<A, B>(a: ImArray<A>, f: A -> ImArray<B>) -> ImArray<B> {
   return ImArray(array:re)
 }
 
+func sort<A:Comparable>(a:ImArray<A>) -> ImArray<A> {
+    return ImArray(array: sort(a.backing.copy()))
+}
+
+func sort<A>(a:ImArray<A>, pred: (A,A) -> Bool) -> ImArray<A> {
+    return ImArray(array: sort(a.backing.copy(), pred))
+}

--- a/swiftzTests/ImArrayTests.swift
+++ b/swiftzTests/ImArrayTests.swift
@@ -91,4 +91,30 @@ class ImArrayTests: XCTestCase {
         XCTAssert(withArray.splitAt(0).0 == ImArray() && withArray.splitAt(0).1 == ImArray(items: 1,2,3,4), "Should be equal")
         XCTAssert(withArray == ImArray(array: [1,2,3,4]), "Should be equal(immutablility test)")
     }
+  
+    func testBuiltInArraySort() {
+        var a = [3,2,1]
+        var b = sort(a)
+        // XCTAssert(a == [3,2,1], "Should be unalterred") - Currently fails (Swift bug)
+        XCTAssert(a != [3,2,1], "Swift bug may be fixed. Update tests and workarounds")
+        var c = [3,2,1]
+        var d = sort(c.copy())
+        XCTAssert(c == [3,2,1], "Should be unalterred")
+        XCTAssert(d == [1,2,3], "Should be sorted")
+        XCTAssert(b == [1,2,3], "Should be sorted")
+    }
+    
+    func testImArraySort() {
+        var a = ImArray(items: 3,2,1)
+        var b = sort(a)
+        XCTAssert(a == ImArray(items: 3,2,1), "Should be unalterred")
+        XCTAssert(b == ImArray(items: 1,2,3), "Should be sorted")
+    }
+    
+    func testImArraySortPred() {
+        var a = ImArray(items: 1,2,3)
+        var b = sort(a) { $0 > $1 }
+        XCTAssert(a == ImArray(items: 1,2,3), "Should be unalterred")
+        XCTAssert(b == ImArray(items: 3,2,1), "Should be sorted in reverse")
+    }
 }


### PR DESCRIPTION
Don't know if you actually want this. It is free sort functions to bring ImArray upto the capability of the builtin array.

The current standard library implementation doesn't match the book as the array returned is the array passed in as an argument only sorted. When that is fixed the copies can be removed from these functions. 

“The Sort Function
Swift’s standard library provides a function called sort, which sorts an array of values of a known type, based on the output of a sorting closure that you provide. Once it completes the sorting process, the sort function returns a new array of the same type and size as the old one, with its elements in the correct sorted order.” The test of the built in array sort will fail to let you know this can happen.

Excerpt From: Apple Inc. “The Swift Programming Language.” iBooks. https://itun.es/gb/jEUH0.l
