### PR TITLE
Proposed extension to Futures to allow initialization without a task

### DIFF
--- a/swiftz/Future.swift
+++ b/swiftz/Future.swift
@@ -20,10 +20,12 @@ class Future<A> {
   let resultQueue = dispatch_queue_create("swift.future", DISPATCH_QUEUE_CONCURRENT)
 
   let execCtx: ExecutionContext // for map
-
-  init(exec: ExecutionContext, a: () -> A) {
-    dispatch_suspend(resultQueue)
-
+  init(exec: ExecutionContext) {
+    dispatch_suspend(self.resultQueue)
+    execCtx = exec
+  }
+  init(exec: ExecutionContext, _ a: () -> A) {
+    dispatch_suspend(self.resultQueue)
     execCtx = exec
     exec.submit(self, work: a)
   }


### PR DESCRIPTION
In some cases you may want to initialize a future and then manually satisfy it by calling `sig(x)` asynchronously.  In my case, it was to work with the Google's GTMHTTPFetcher's `beginFetchWithCompletionHandler` method.

It works for me and I believe it doesn't threaten any of the underlying semantics.  
