### PR TITLE
Add `@infix`

### DIFF
--- a/swiftz/ImArray.swift
+++ b/swiftz/ImArray.swift
@@ -206,15 +206,15 @@ extension ImArray {
     }
 }
 
-func ==<A:Equatable>(lhs:ImArray<A>, rhs:ImArray<A>) -> Bool {
+@infix func ==<A:Equatable>(lhs:ImArray<A>, rhs:ImArray<A>) -> Bool {
     return lhs.array == rhs.array
 }
 
-func !=<A:Equatable>(lhs:ImArray<A>, rhs:ImArray<A>) -> Bool {
+@infix func !=<A:Equatable>(lhs:ImArray<A>, rhs:ImArray<A>) -> Bool {
     return !(lhs.array == rhs.array)
 }
 
-func +=<A>(lhs:ImArray<A>, rhs:A) -> ImArray<A> {
+@infix func +=<A>(lhs:ImArray<A>, rhs:A) -> ImArray<A> {
     return lhs.append(rhs)
 }
 
@@ -224,11 +224,11 @@ func pure<A>(a:A) -> ImArray<A> {
   return ImArray(item:a)
 }
 
-func<^><A, B>(f:A -> B, a:ImArray<A>) -> ImArray<B> {
+@infix func <^><A, B>(f:A -> B, a:ImArray<A>) -> ImArray<B> {
   return a.map(f)
 }
 
-func <*><A, B>(f:ImArray<A -> B>, a:ImArray<A>) -> ImArray<B> {
+@infix func <*><A, B>(f:ImArray<A -> B>, a:ImArray<A>) -> ImArray<B> {
   var re = [B]()
   for g in f {
     for h in a {
@@ -238,7 +238,7 @@ func <*><A, B>(f:ImArray<A -> B>, a:ImArray<A>) -> ImArray<B> {
   return ImArray(array:re)
 }
 
-func >>=<A, B>(a: ImArray<A>, f: A -> ImArray<B>) -> ImArray<B> {
+@infix func >>=<A, B>(a: ImArray<A>, f: A -> ImArray<B>) -> ImArray<B> {
   var re = [B]()
   for x in a {
     re.extend(f(x))

--- a/swiftz/IxCont.swift
+++ b/swiftz/IxCont.swift
@@ -45,23 +45,23 @@ func pure<R, A>(x: A) -> IxCont<R, R, A> {
   return IxCont { $0(x) }
 }
 
-func <^><R, O, A, B>(f: A -> B, a: IxCont<R, O, A>) -> IxCont<R, O, B> {
+@infix func <^><R, O, A, B>(f: A -> B, a: IxCont<R, O, A>) -> IxCont<R, O, B> {
   return IxCont { k in a.run { k(f($0)) } }
 }
 
-func <^^><R, S, O, A>(f: R -> S, a: IxCont<R, O, A>) -> IxCont<S, O, A> {
+@infix func <^^><R, S, O, A>(f: R -> S, a: IxCont<R, O, A>) -> IxCont<S, O, A> {
   return IxCont { f(a.run($0)) }
 }
 
-func <!><R, N, O, A>(f: N -> O, a: IxCont<R, O, A>) -> IxCont<R, N, A> {
+@infix func <!><R, N, O, A>(f: N -> O, a: IxCont<R, O, A>) -> IxCont<R, N, A> {
   return IxCont { k in a.run { f(k($0)) } }
 }
 
-func <*><R, I, O, A, B>(f: IxCont<R, I, A -> B>, a: IxCont<I, O, A>) -> IxCont<R, O, B> {
+@infix func <*><R, I, O, A, B>(f: IxCont<R, I, A -> B>, a: IxCont<I, O, A>) -> IxCont<R, O, B> {
   return IxCont { k in f.run { g in a.run { k(g($0)) } } }
 }
 
-func >>=<R, I, O, A, B>(a: IxCont<R, I, A>, f: A -> IxCont<I, O, B>) -> IxCont<R, O, B> {
+@infix func >>=<R, I, O, A, B>(a: IxCont<R, I, A>, f: A -> IxCont<I, O, B>) -> IxCont<R, O, B> {
   return IxCont { k in a.run { f($0).run(k) } }
 }
 

--- a/swiftz/IxState.swift
+++ b/swiftz/IxState.swift
@@ -49,25 +49,25 @@ func pure<I, A>(x: A) -> IxState<I, I, A> {
      return IxState { (x, $0) }
 }
 
-func <^><I, O, A, B>(f: A -> B, a: IxState<I, O, A>) -> IxState<I, O, B> {
+@infix func <^><I, O, A, B>(f: A -> B, a: IxState<I, O, A>) -> IxState<I, O, B> {
      return IxState { s1 in
           let (x, s2) = a.run(s1)
           return (f(x), s2)
      }
 }
 
-func <!><H, I, O, A>(f: H -> I, a: IxState<I, O, A>) -> IxState<H, O, A> {
+@infix func <!><H, I, O, A>(f: H -> I, a: IxState<I, O, A>) -> IxState<H, O, A> {
      return IxState { a.run(f($0)) }
 }
 
-func <^^><I, O, P, A>(f: O -> P, a: IxState<I, O, A>) -> IxState<I, P, A> {
+@infix func <^^><I, O, P, A>(f: O -> P, a: IxState<I, O, A>) -> IxState<I, P, A> {
      return IxState { s1 in
           let (x, s2) = a.run(s1)
           return (x, f(s2))
      }
 }
 
-//func <*><I, J, O, A, B>(f: IxState<I, J, A -> B>, a: IxState<J, O, A>) -> IxState<I, O, B> {
+//@infix func <*><I, J, O, A, B>(f: IxState<I, J, A -> B>, a: IxState<J, O, A>) -> IxState<I, O, B> {
 //     return IxState { s1 in
 //          let (g, s2) = f.run(s1)
 //          let (x, s3) = a.run(s2)
@@ -75,7 +75,7 @@ func <^^><I, O, P, A>(f: O -> P, a: IxState<I, O, A>) -> IxState<I, P, A> {
 //     }
 //}
 
-func >>=<I, J, O, A, B>(a: IxState<I, J, A>, f: A -> IxState<J, O, B>) -> IxState<I, O, B> {
+@infix func >>=<I, J, O, A, B>(a: IxState<I, J, A>, f: A -> IxState<J, O, B>) -> IxState<I, O, B> {
      return IxState { s1 in
           let (x, s2) = a.run(s1)
           return f(x).run(s2)

--- a/swiftz/IxStore.swift
+++ b/swiftz/IxStore.swift
@@ -67,15 +67,15 @@ func extract<I, A>(a: IxStore<I, I, A>) -> A {
      return a.set(a.pos)
 }
 
-func <^><O, I, A, B>(f: A -> B, a: IxStore<O, I, A>) -> IxStore<O, I, B> {
+@infix func <^><O, I, A, B>(f: A -> B, a: IxStore<O, I, A>) -> IxStore<O, I, B> {
      return IxStore(a.pos) { f(a.set($0)) }
 }
 
-func<^^><O, P, I, A>(f: O -> P, a: IxStore<O, I, A>) -> IxStore<P, I, A> {
+@infix func<^^><O, P, I, A>(f: O -> P, a: IxStore<O, I, A>) -> IxStore<P, I, A> {
      return IxStore(f(a.pos), a.set)
 }
 
-func <!><O, H, I, A>(f: H -> I, a: IxStore<O, I, A>) -> IxStore<O, H, A> {
+@infix func <!><O, H, I, A>(f: H -> I, a: IxStore<O, I, A>) -> IxStore<O, H, A> {
      return IxStore(a.pos) { a.set(f($0)) }
 }
 
@@ -83,7 +83,7 @@ func duplicate<O, J, I, A>(a: IxStore<O, I, A>) -> IxStore<O, J, IxStore<J, I, A
      return IxStore(a.pos) { IxStore($0, a.set) }
 }
 
-func =>><O, J, I, A, B>(a: IxStore<O, I, A>, f: IxStore<J, I, A> -> B) -> IxStore<O, J, B> {
+@infix func =>><O, J, I, A, B>(a: IxStore<O, I, A>, f: IxStore<J, I, A> -> B) -> IxStore<O, J, B> {
      return IxStore(a.pos) { f(IxStore($0, a.set)) }
 }
 

--- a/swiftz/Lens.swift
+++ b/swiftz/Lens.swift
@@ -58,7 +58,7 @@ func comp<S, T, I, J, A, B>(l1: Lens<S, T, I, J>)(l2: Lens<I, J, A, B>) -> Lens<
      }
 }
 
-func •<S, T, I, J, A, B>(l1: Lens<S, T, I, J>, l2: Lens<I, J, A, B>) -> Lens<S, T, A, B> {
+@infix func •<S, T, I, J, A, B>(l1: Lens<S, T, I, J>, l2: Lens<I, J, A, B>) -> Lens<S, T, A, B> {
 	return Lens { v in
 		let q1 = l1.run(v)
 		let q2 = l2.run(q1.pos)

--- a/swiftz/MaybeFunctor.swift
+++ b/swiftz/MaybeFunctor.swift
@@ -48,7 +48,7 @@ extension Maybe: LogicValue {
 	}
 }
 
-func ==<A: Equatable>(lhs: Maybe<A>, rhs: Maybe<A>) -> Bool {
+@infix func ==<A: Equatable>(lhs: Maybe<A>, rhs: Maybe<A>) -> Bool {
 	if !lhs && !rhs {
 		return true
 	}

--- a/swiftz/NonEmptyList.swift
+++ b/swiftz/NonEmptyList.swift
@@ -26,7 +26,7 @@ func tail<A>() -> Lens<NonEmptyList<A>, NonEmptyList<A>, List<A>, List<A>> {
      return Lens { nel in IxStore(nel.tail) { NonEmptyList(nel.head.value, $0) } }
 }
 
-func ==<A : Equatable>(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> Bool {
+@infix func ==<A : Equatable>(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> Bool {
   return (lhs.head.value == rhs.head.value && lhs.tail == rhs.tail)
 }
 

--- a/swiftz/Set.swift
+++ b/swiftz/Set.swift
@@ -170,15 +170,15 @@ extension Set : ArrayLiteralConvertible {
     }
 }
 
-func ==<A: Equatable, B: Equatable>(lhs:Set<A>, rhs:Set<B>) -> Bool {
+@infix func ==<A: Equatable, B: Equatable>(lhs:Set<A>, rhs:Set<B>) -> Bool {
     return lhs.bucket == rhs.bucket
 }
 
-func !=<A: Equatable, B: Equatable>(lhs:Set<A>, rhs:Set<B>) -> Bool {
+@infix func !=<A: Equatable, B: Equatable>(lhs:Set<A>, rhs:Set<B>) -> Bool {
     return lhs.bucket != rhs.bucket
 }
 
-func +=<A>(set:Set<A>, item:A) -> Set<A> {
+@infix func +=<A>(set:Set<A>, item:A) -> Set<A> {
     if set.contains(item) {
         return set
     } else {
@@ -188,15 +188,15 @@ func +=<A>(set:Set<A>, item:A) -> Set<A> {
     }
 }
 
-func -<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
+@infix func -<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
     return lhs.minus(rhs)
 }
 
-func ∩<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
+@infix func ∩<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
     return lhs.intersect(rhs)
 }
 
-func ∪<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
+@infix func ∪<A>(lhs:Set<A>, rhs:Set<A>) -> Set<A> {
     return lhs.union(rhs)
 }
 
@@ -206,17 +206,17 @@ func pure<A>(a:A) -> Set<A> {
   return Set(items: a)
 }
 
-func <^><A, B>(f: A -> B, set:Set<A>) -> Set<B> {
+@infix func <^><A, B>(f: A -> B, set:Set<A>) -> Set<B> {
   return set.map(f)
 }
 
 // Can't do applicative on a Set currently
-//func <*><A, B>(f:Set<A -> B>, a:Set<A>) -> Set<B> {
+//@infix func <*><A, B>(f:Set<A -> B>, a:Set<A>) -> Set<B> {
 //
 //    return Set<B>()
 //}
 
-func >>=<A, B>(a:Set<A>, f: A -> Set<B>) -> Set<B> {
+@infix func >>=<A, B>(a:Set<A>, f: A -> Set<B>) -> Set<B> {
   var se = [B]()
   for x in a {
     se.extend(f(x))

--- a/swiftz/TupleExt.swift
+++ b/swiftz/TupleExt.swift
@@ -35,52 +35,52 @@ func snd<A, B, C>() -> Lens<(A, B), (A, C), B, C> {
 //extension (T:Equatable, U:Equatable) : Equatable {}
 
 
-func ==(lhs: (), rhs: ()) -> Bool {
+@infix func ==(lhs: (), rhs: ()) -> Bool {
   return true
 }
-func !=(lhs: (), rhs: ()) -> Bool { return false }
+@infix func !=(lhs: (), rhs: ()) -> Bool { return false }
 
 // Unlike Python a 1-tuple is just it's contained element.
 
-func == <T:Equatable,U:Equatable>(lhs: (T,U), rhs: (T,U)) -> Bool {
+@infix func == <T:Equatable,U:Equatable>(lhs: (T,U), rhs: (T,U)) -> Bool {
     let (l0,l1) = lhs
     let (r0,r1) = rhs
     return l0 == r0 && l1 == r1
 }
-func != <T:Equatable,U:Equatable>(lhs: (T,U), rhs: (T,U)) -> Bool {
+@infix func != <T:Equatable,U:Equatable>(lhs: (T,U), rhs: (T,U)) -> Bool {
   return !(lhs==rhs)
 }
 
-func == <T:Equatable,U:Equatable,V:Equatable>(lhs: (T,U,V), rhs: (T,U,V)) -> Bool {
+@infix func == <T:Equatable,U:Equatable,V:Equatable>(lhs: (T,U,V), rhs: (T,U,V)) -> Bool {
     let (l0,l1,l2) = lhs
     let (r0,r1,r2) = rhs
     return l0 == r0 && l1 == r1 && l2 == r2
 }
-func != <T:Equatable,U:Equatable,V:Equatable>(lhs: (T,U,V), rhs: (T,U,V)) -> Bool {
+@infix func != <T:Equatable,U:Equatable,V:Equatable>(lhs: (T,U,V), rhs: (T,U,V)) -> Bool {
   return !(lhs==rhs)
 }
 
-func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable>(lhs: (T,U,V,W), rhs: (T,U,V,W)) -> Bool {
+@infix func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable>(lhs: (T,U,V,W), rhs: (T,U,V,W)) -> Bool {
     let (l0,l1,l2,l3) = lhs
     let (r0,r1,r2,r3) = rhs
     return l0 == r0 && l1 == r1 && l2 == r2 && l3 == r3
 }
-func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable>(lhs: (T,U,V,W), rhs: (T,U,V,W)) -> Bool {
+@infix func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable>(lhs: (T,U,V,W), rhs: (T,U,V,W)) -> Bool {
   return !(lhs==rhs)
   }
-func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable>(lhs: (T,U,V,W,X), rhs: (T,U,V,W,X)) -> Bool {
+@infix func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable>(lhs: (T,U,V,W,X), rhs: (T,U,V,W,X)) -> Bool {
     let (l0,l1,l2,l3,l4) = lhs
     let (r0,r1,r2,r3,r4) = rhs
     return l0 == r0 && l1 == r1 && l2 == r2 && l3 == r3 && l4 == r4
 }
-func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable>(lhs: (T,U,V,W,X), rhs: (T,U,V,W,X)) -> Bool {
+@infix func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable>(lhs: (T,U,V,W,X), rhs: (T,U,V,W,X)) -> Bool {
   return !(lhs==rhs)
 }
-func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable,Z:Equatable>(lhs: (T,U,V,W,X,Z), rhs: (T,U,V,W,X,Z)) -> Bool {
+@infix func == <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable,Z:Equatable>(lhs: (T,U,V,W,X,Z), rhs: (T,U,V,W,X,Z)) -> Bool {
     let (l0,l1,l2,l3,l4,l5) = lhs
     let (r0,r1,r2,r3,r4,r5) = rhs
     return l0 == r0 && l1 == r1 && l2 == r2 && l3 == r3 && l4 == r4 && l5 == r5
 }
-func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable,Z:Equatable>(lhs: (T,U,V,W,X,Z), rhs: (T,U,V,W,X,Z)) -> Bool {
+@infix func != <T:Equatable,U:Equatable,V:Equatable,W:Equatable,X:Equatable,Z:Equatable>(lhs: (T,U,V,W,X,Z), rhs: (T,U,V,W,X,Z)) -> Bool {
   return !(lhs==rhs)
 }

--- a/swiftzTests/ShapeExample.swift
+++ b/swiftzTests/ShapeExample.swift
@@ -40,7 +40,7 @@ enum Shape : Dataable {
   }
 }
 
-func ==(lhs: Shape, rhs: Shape) -> Bool {
+@infix func ==(lhs: Shape, rhs: Shape) -> Bool {
   switch (lhs, rhs) {
     case (.Boat, .Boat): return true
     case let (.Plane(q), .Plane(w)) where w == q: return true

--- a/swiftz_core/swiftz_core/Array.swift
+++ b/swiftz_core/swiftz_core/Array.swift
@@ -17,7 +17,7 @@ func pure<A>(a: A) -> [A] {
 }
 
 // Note! This is not map! Map mutates the array, this copies it.
-func <^><A, B>(f: A -> B, a: [A]) -> [B] {
+@infix func <^><A, B>(f: A -> B, a: [A]) -> [B] {
   var xs = [B]()
   for x in a {
     xs.append(f(x))
@@ -25,7 +25,7 @@ func <^><A, B>(f: A -> B, a: [A]) -> [B] {
   return xs
 }
 
-func <*><A, B>(f: [(A -> B)], a: [A]) -> [B] {
+@infix func <*><A, B>(f: [(A -> B)], a: [A]) -> [B] {
   var re = [B]()
   for g in f {
     for h in a {
@@ -35,7 +35,7 @@ func <*><A, B>(f: [(A -> B)], a: [A]) -> [B] {
   return re
 }
 
-func >>=<A, B>(a: [A], f: A -> [B]) -> [B] {
+@infix func >>=<A, B>(a: [A], f: A -> [B]) -> [B] {
   var re = [B]()
   for x in a {
     re.extend(f(x))

--- a/swiftz_core/swiftz_core/Box.swift
+++ b/swiftz_core/swiftz_core/Box.swift
@@ -21,3 +21,7 @@
     return Box<U>(fn(value)) // TODO: file rdar, type inf fails without <U>
   }
 }
+
+@infix func <^><T, U>(fn: T -> U, x: Box<T>) -> Box<U> {
+  return x.map(fn)
+}

--- a/swiftz_core/swiftz_core/Either.swift
+++ b/swiftz_core/swiftz_core/Either.swift
@@ -40,7 +40,7 @@ enum Either<L, R> {
 }
 
 // Equatable
-func ==<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Bool {
+@infix func ==<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Bool {
   switch (lhs, rhs) {
     case let (.Left(l), .Left(r)) where l.value == r.value: return true
     case let (.Right(l), .Right(r)) where l.value == r.value: return true
@@ -48,7 +48,7 @@ func ==<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Boo
   }
 }
 
-func !=<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Bool {
+@infix func !=<L: Equatable, R: Equatable>(lhs: Either<L, R>, rhs: Either<L, R>) -> Bool {
   return !(lhs == rhs)
 }
 
@@ -58,14 +58,14 @@ func pure<L, R>(a: R) -> Either<L, R> {
   return .Right(Box(a))
 }
 
-func <^><L, RA, RB>(f: RA -> RB, a: Either<L, RA>) -> Either<L, RB> {
+@infix func <^><L, RA, RB>(f: RA -> RB, a: Either<L, RA>) -> Either<L, RB> {
   switch a {
     case let .Left(l): return .Left(l)
     case let .Right(r): return Either<L, RB>.Right(Box(f(r.value)))
   }
 }
 
-func <*><L, RA, RB>(f: Either<L, RA -> RB>, a: Either<L, RA>) -> Either<L, RB> {
+@infix func <*><L, RA, RB>(f: Either<L, RA -> RB>, a: Either<L, RA>) -> Either<L, RB> {
   switch a {
     case let .Left(l): return .Left(l)
     case let .Right(r): switch f {
@@ -75,7 +75,7 @@ func <*><L, RA, RB>(f: Either<L, RA -> RB>, a: Either<L, RA>) -> Either<L, RB> {
     }
 }
 
-func >>=<L, RA, RB>(a: Either<L, RA>, f: RA -> Either<L, RB>) -> Either<L, RB> {
+@infix func >>=<L, RA, RB>(a: Either<L, RA>, f: RA -> Either<L, RB>) -> Either<L, RB> {
   switch a {
     case let .Left(l): return .Left(l)
     case let .Right(r): return f(r.value)

--- a/swiftz_core/swiftz_core/Functions.swift
+++ b/swiftz_core/swiftz_core/Functions.swift
@@ -27,14 +27,14 @@ func flip<A, B, C>(f: A -> B -> C)(b: B)(a: A) -> C {
 }
 
 // Function composition. Alt + 8
-func •<A, B, C>(f: B -> C, g: A -> B) -> A -> C {
+@infix func •<A, B, C>(f: B -> C, g: A -> B) -> A -> C {
   return { (a: A) -> C in
     return f(g(a))
   }
 }
 
 // Thrush
-func |><A, B>(a: A, f: A -> B) -> B {
+@infix func |><A, B>(a: A, f: A -> B) -> B {
   return f(a)
 }
 
@@ -48,28 +48,28 @@ func |><A, B>(a: A, f: A -> B) -> B {
 // functions as a monad and profunctor
 
 // •
-func <^><I, A, B>(f: A -> B, k: I -> A) -> (I -> B) {
+@infix func <^><I, A, B>(f: A -> B, k: I -> A) -> (I -> B) {
   return { x in
     f(k(x))
   }
 }
 
 // flip(•)
-func <!><I, J, A>(f: J -> I, k: I -> A) -> (J -> A) {
+@infix func <!><I, J, A>(f: J -> I, k: I -> A) -> (J -> A) {
   return { x in
     k(f(x))
   }
 }
 
 // the S combinator
-func <*><I, A, B>(f: I -> (A -> B), k: I -> A) -> (I -> B) {
+@infix func <*><I, A, B>(f: I -> (A -> B), k: I -> A) -> (I -> B) {
   return { x in
     f(x)(k(x))
   }
 }
 
 // the S' combinator
-func >>=<I, A, B>(f: A -> (I -> B), k: I -> A) -> (I -> B) {
+@infix func >>=<I, A, B>(f: A -> (I -> B), k: I -> A) -> (I -> B) {
   return { x in
     f(k(x))(x)
   }

--- a/swiftz_core/swiftz_core/List.swift
+++ b/swiftz_core/swiftz_core/List.swift
@@ -63,7 +63,7 @@ enum List<A> {
   }
 }
 
-func==<A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {
+@infix func ==<A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {
   switch (lhs, rhs) {
   case (.Nil, .Nil):
     return true

--- a/swiftz_core/swiftz_core/Optional.swift
+++ b/swiftz_core/swiftz_core/Optional.swift
@@ -14,7 +14,7 @@ func pure<A>(a: A) -> A? {
   return a
 }
 
-func <^><A, B>(f: A -> B, a: A?) -> B? {
+@infix func <^><A, B>(f: A -> B, a: A?) -> B? {
   if let x = a {
     return (f(x))
   } else {
@@ -22,7 +22,7 @@ func <^><A, B>(f: A -> B, a: A?) -> B? {
   }
 }
 
-func <*><A, B>(f: (A -> B)?, a: A?) -> B? {
+@infix func <*><A, B>(f: (A -> B)?, a: A?) -> B? {
   if f && a {
     return (f!(a!))
   } else {
@@ -32,7 +32,7 @@ func <*><A, B>(f: (A -> B)?, a: A?) -> B? {
 
 // the "if the arg is Some, apply the function that returns an optional
 // value and if the arg is None, just return None" function.
-func >>=<A, B>(a: A?, f: A -> B?) -> B? {
+@infix func >>=<A, B>(a: A?, f: A -> B?) -> B? {
   if let x = a {
     return f(x)
   } else {

--- a/swiftz_core/swiftz_core/Result.swift
+++ b/swiftz_core/swiftz_core/Result.swift
@@ -50,7 +50,7 @@ enum Result<V> {
 }
 
 // Equatable
-func ==<V: Equatable>(lhs: Result<V>, rhs: Result<V>) -> Bool {
+@infix func ==<V: Equatable>(lhs: Result<V>, rhs: Result<V>) -> Bool {
   switch (lhs, rhs) {
     case let (.Error(l), .Error(r)) where l == r: return true
     case let (.Value(l), .Value(r)) where l.value == r.value: return true
@@ -58,7 +58,7 @@ func ==<V: Equatable>(lhs: Result<V>, rhs: Result<V>) -> Bool {
   }
 }
 
-func !=<V: Equatable>(lhs: Result<V>, rhs: Result<V>) -> Bool {
+@infix func !=<V: Equatable>(lhs: Result<V>, rhs: Result<V>) -> Bool {
   return !(lhs == rhs)
 }
 
@@ -68,14 +68,14 @@ func pure<V>(a: V) -> Result<V> {
   return .Value(Box(a))
 }
 
-func <^><VA, VB>(f: VA -> VB, a: Result<VA>) -> Result<VB> {
+@infix func <^><VA, VB>(f: VA -> VB, a: Result<VA>) -> Result<VB> {
   switch a {
   case let .Error(l): return .Error(l)
   case let .Value(r): return Result.Value(Box(f(r.value)))
   }
 }
 
-func <*><VA, VB>(f: Result<VA -> VB>, a: Result<VA>) -> Result<VB> {
+@infix func <*><VA, VB>(f: Result<VA -> VB>, a: Result<VA>) -> Result<VB> {
   switch (a, f) {
   case let (.Error(l), _): return .Error(l)
   case let (.Value(r), .Error(m)): return .Error(m)
@@ -83,7 +83,7 @@ func <*><VA, VB>(f: Result<VA -> VB>, a: Result<VA>) -> Result<VB> {
   }
 }
 
-func >>=<VA, VB>(a: Result<VA>, f: VA -> Result<VB>) -> Result<VB> {
+@infix func >>=<VA, VB>(a: Result<VA>, f: VA -> Result<VB>) -> Result<VB> {
   switch a {
   case let .Error(l): return .Error(l)
   case let .Value(r): return f(r.value)


### PR DESCRIPTION
Even if it seems unnecessary now, we shouldn't assume the Swift compiler will always let us off so easily regarding this part of the language spec.  Regardless, it seems like good practice, anyway.
