### PR TITLE
Use optional return if JSON cannot be parsed

### DIFF
--- a/swiftz/JSON.swift
+++ b/swiftz/JSON.swift
@@ -57,11 +57,16 @@ public enum JSValue: Printable {
   }
   
   // TODO: should this be optional?
-  public static func decode(s: NSData) -> JSValue {
+  public static func decode(s: NSData) -> JSValue? {
     var e: NSError?
     let opts: NSJSONReadingOptions = nil
-    let r: AnyObject = NSJSONSerialization.JSONObjectWithData(s, options: opts, error: &e)
-    return make(r as NSObject)
+    let r: AnyObject? = NSJSONSerialization.JSONObjectWithData(s, options: opts, error: &e)
+
+    if let json: AnyObject = r {
+      return make(json as NSObject)
+    } else {
+      return .None
+    }
   }
   
   public var description: String {

--- a/swiftzTests/DataTests.swift
+++ b/swiftzTests/DataTests.swift
@@ -169,9 +169,10 @@ class DataTests: XCTestCase {
 
   func testDataJSON() {
     let js: NSData = "[1,\"foo\"]".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
-    let lhs: JSValue = JSValue.decode(js)
+    let lhs: JSValue? = JSValue.decode(js)
     let rhs: JSValue = .JSArray([.JSNumber(1), .JSString("foo")])
-    XCTAssert(lhs == rhs)
+    XCTAssertTrue(lhs)
+    XCTAssert(lhs! == rhs)
     XCTAssert(rhs.encode() == js)
     
     // user example
@@ -186,6 +187,12 @@ class DataTests: XCTestCase {
     if notUser {
       XCTFail("expected none")
     }
+  }
+
+  func testInvalidDataJSON() {
+    let js: NSData = "[1,foo\"]".dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+    let json: JSValue? = JSValue.decode(js)
+    XCTAssertFalse(json)
   }
   
   func testHList() {


### PR DESCRIPTION
Return an optional JSValue just in case the json cannot be parsed.  Right now it throws an exception.
