### PR TITLE
removed deriveddata path from FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/swiftz.xcodeproj/project.pbxproj
+++ b/swiftz.xcodeproj/project.pbxproj
@@ -746,10 +746,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/swiftz-caubilaqvpmvcjdzvtqopnzfrawa/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -774,10 +771,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/swiftz-caubilaqvpmvcjdzvtqopnzfrawa/Build/Products/Debug",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = swiftz_ios/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;


### PR DESCRIPTION
This will address warnings such as the one in the screen shot below:

![screen shot 2014-07-23 at 10 13 27 pm](https://cloud.githubusercontent.com/assets/646732/3683945/87bd3320-12f1-11e4-8dfc-b8b255300255.png)
