### PR TITLE
Added  either<A>(onL: L -> A, onR: R -> A) -> A  function

### DIFF
--- a/swiftz_core/swiftz_core/Either.swift
+++ b/swiftz_core/swiftz_core/Either.swift
@@ -37,6 +37,13 @@ public enum Either<L, R> {
   public static func right(r: R) -> Either<L, R> {
     return .Right(Box(r))
   }
+
+  public func either<A>(onL: L -> A, onR: R -> A) -> A {
+    switch self {
+        case let Left(e): return onL(e.value)
+        case let Right(e): return onR(e.value)
+    }
+  }
 }
 
 // Equatable


### PR DESCRIPTION
Nice little convenience from the haskell world:

``` haskell
either :: either a b -> (a -> c) -> (b -> c) -> c
```
