### PR TITLE
Replace most Foundation imports with Darwin or nothing

### DIFF
--- a/swiftz/ArrayZipper.swift
+++ b/swiftz/ArrayZipper.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public final class ArrayZipper<A>: ArrayLiteralConvertible {

--- a/swiftz/Chan.swift
+++ b/swiftz/Chan.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Darwin
 
 // An unbound FIFO channel.
 // http://www.haskell.org/ghc/docs/latest/html/libraries/base/Control-Concurrent-Chan.html

--- a/swiftz/Curry.swift
+++ b/swiftz/Curry.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public func curry<A, B, C>(f: (A, B) -> C, a: A, b: B) -> C {
   return f((a, b))
 }

--- a/swiftz/ExecutionContext.swift
+++ b/swiftz/ExecutionContext.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 // Implement this protocol to be an execution context.
 // for example, a lightweight threading runtime...
 public protocol ExecutionContext {

--- a/swiftz/Future.swift
+++ b/swiftz/Future.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Dispatch
 import swiftz_core
 
 public class Future<A> {

--- a/swiftz/GCDExecutionContext.swift
+++ b/swiftz/GCDExecutionContext.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Dispatch
 
 public let gcdExecutionContext = GCDExecutionContext()
 public let gcdDispatchQueueGlobal = dispatch_queue_create("swiftz.global", DISPATCH_QUEUE_CONCURRENT)

--- a/swiftz/HList.swift
+++ b/swiftz/HList.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Darwin
 import swiftz_core
 
 // A HList can be thought of like a tuple, but with list-like operations on the types.

--- a/swiftz/Iso.swift
+++ b/swiftz/Iso.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public class Iso<S, T, A, B> {

--- a/swiftz/IxCont.swift
+++ b/swiftz/IxCont.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public struct IxCont<R, O, A> {

--- a/swiftz/IxMultiStore.swift
+++ b/swiftz/IxMultiStore.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 // N.B.:  This is the "inlining" of the indexed store comonad transformer

--- a/swiftz/IxState.swift
+++ b/swiftz/IxState.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public struct IxState<I, O, A> {

--- a/swiftz/IxStore.swift
+++ b/swiftz/IxStore.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 // N.B.:  In the indexed store comonad transformer, set, put, and peek are all distinct,

--- a/swiftz/Lens.swift
+++ b/swiftz/Lens.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public class Lens<S, T, A, B> {

--- a/swiftz/MVar.swift
+++ b/swiftz/MVar.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Darwin
 
 // Reading an MVar that is empty will block until it has something in it.
 // Putting into an MVar will block if it has something in it, until someone reads from it.

--- a/swiftz/MaybeFunctor.swift
+++ b/swiftz/MaybeFunctor.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Josh Abernathy. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public class Maybe<A: Any>: F<A> {

--- a/swiftz/NonEmptyList.swift
+++ b/swiftz/NonEmptyList.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public struct NonEmptyList<A> {

--- a/swiftz/Prism.swift
+++ b/swiftz/Prism.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz_core
 
 public class Prism<S, T, A, B> {

--- a/swiftz/SYB.swift
+++ b/swiftz/SYB.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public protocol Dataable {
   class func typeRep() -> Any.Type
   class func fromRep(r: Data) -> Self?

--- a/swiftz/Set.swift
+++ b/swiftz/Set.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
+import Darwin
 import swiftz_core
 
 infix operator ∩ {}

--- a/swiftz/StringExt.swift
+++ b/swiftz/StringExt.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 extension String {
   public func lines() -> [String] {
     var xs: [String] = []

--- a/swiftz/Tuple.swift
+++ b/swiftz/Tuple.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 // A tuple you can use in type parameters
 public struct Tuple2<A, B> {
   public let a: A

--- a/swiftz/TupleExt.swift
+++ b/swiftz/TupleExt.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 // the standard library has _.1, _.2 functions
 // these functions are more useful when "doing fp" (point-free-ish forms)
 public func fst<A, B>(ab: (A, B)) -> A {

--- a/swiftzTests/PartyExample.swift
+++ b/swiftzTests/PartyExample.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz
 
 // A party has a host, who is a user.

--- a/swiftzTests/ShapeExample.swift
+++ b/swiftzTests/ShapeExample.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz
 import swiftz_core
 

--- a/swiftzTests/UserExample.swift
+++ b/swiftzTests/UserExample.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 import swiftz
 import swiftz_core
 

--- a/swiftz_core/swiftz_core/Applicative.swift
+++ b/swiftz_core/swiftz_core/Applicative.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public protocol Applicative : Functor {
   typealias FA = F<A>
   typealias FAB = F<A -> B>

--- a/swiftz_core/swiftz_core/Array.swift
+++ b/swiftz_core/swiftz_core/Array.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 /// Applicative `pure` function, lifts a value into an Array.
 public func pure<A>(a: A) -> [A] {
   return [a]

--- a/swiftz_core/swiftz_core/Bifunctor.swift
+++ b/swiftz_core/swiftz_core/Bifunctor.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public class P<A, B> {
   public init() {
 

--- a/swiftz_core/swiftz_core/Comonad.swift
+++ b/swiftz_core/swiftz_core/Comonad.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public protocol Comonad : Functor {
   typealias FAB = F<A> -> B
   func extract() -> A

--- a/swiftz_core/swiftz_core/Functions.swift
+++ b/swiftz_core/swiftz_core/Functions.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 // the building blocks of FP
 
 /// The identity function, which returns its argument.

--- a/swiftz_core/swiftz_core/Functor.swift
+++ b/swiftz_core/swiftz_core/Functor.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Josh Abernathy. All rights reserved.
 //
 
-import Foundation
-
 public class F<A> {
   public init() {
 

--- a/swiftz_core/swiftz_core/List.swift
+++ b/swiftz_core/swiftz_core/List.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 /// A recursive List, with the same basic usage as Array.
 /// This is not currently possible with a bit of misdirection, hence the Box class.
 public enum List<A> {

--- a/swiftz_core/swiftz_core/Monad.swift
+++ b/swiftz_core/swiftz_core/Monad.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 public protocol Monad : Applicative {
   typealias AFB = A -> F<B>
   func bind(f: AFB) -> FB

--- a/swiftz_core/swiftz_core/Nothing.swift
+++ b/swiftz_core/swiftz_core/Nothing.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
 /// An enum that represents Nothing
 public enum Nothing {
 

--- a/swiftz_core/swiftz_core/Operators.swift
+++ b/swiftz_core/swiftz_core/Operators.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 // Operators
 infix operator • {
 associativity right

--- a/swiftz_core/swiftz_core/Optional.swift
+++ b/swiftz_core/swiftz_core/Optional.swift
@@ -6,8 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-import Foundation
-
 /// Applicative `pure` function, lifts a value into an Optional.
 public func pure<A>(a: A) -> A? {
     return .Some(a)

--- a/swiftz_core/swiftz_core/Result.swift
+++ b/swiftz_core/swiftz_core/Result.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Maxwell Swadling. All rights reserved.
 //
 
-
 import Foundation
 
 /// Result is similar to an Either, except specialized to have an Error case that can


### PR DESCRIPTION
Importing `Foundation` is only really necessary when using `NSArray`, `NSDictionary`, etc.; for GCD you can import `Dispatch`; for pthreads you can import `Darwin`; otherwise, no import is necessary.
