### PR TITLE
Fix decoding of strings with % character

### DIFF
--- a/swiftz/JSON.swift
+++ b/swiftz/JSON.swift
@@ -42,7 +42,7 @@ public enum JSONValue: Printable {
     case let xs as NSNumber:
       // TODO: number or bool?...
       return .JSONNumber(Double(xs.doubleValue))
-    case let xs as NSString: return .JSONString(String(format: xs))
+    case let xs as NSString: return .JSONString(String(xs))
     case let xs as NSNull: return .JSONNull()
     default: // TODO: what is swift's assert?
       perror("impossible"); abort()


### PR DESCRIPTION
The `JSONString` enum member has an associated `String` value. The
`make(a: NSObject)` method attempts to convert its `NSString` value to a
`String` value by passing it to `String(format:)` and never provides any
arguments. Therefore it fails to decode any string that contains a
`%` character. This changes it to call to `String(_)`.
