### PR TITLE
Don't convert NSString to String using format:

### DIFF
--- a/swiftz/JSON.swift
+++ b/swiftz/JSON.swift
@@ -45,12 +45,12 @@ public enum JSONValue: Printable {
 			return .JSONArray(xs.mapToArray { self.make($0 as NSObject) })
 		case let xs as NSDictionary:
 			return JSONValue.JSONObject(xs.mapValuesToDictionary { (k: AnyObject, v: AnyObject) in
-				return (String(format: k as NSString), self.make(v as NSObject))
+				return (String(k as NSString), self.make(v as NSObject))
 			})
 		case let xs as NSNumber: // TODO: number or bool?...
 			return .JSONNumber(Double(xs.doubleValue))
 		case let xs as NSString: 
-			return .JSONString(String(format: xs))
+			return .JSONString(String(xs))
 		case let xs as NSNull: 
 			return .JSONNull()
 		default: // TODO: what is swift's assert?


### PR DESCRIPTION
The make(a: NSObject) method attempts to convert its NSString value to
a String value by passing it to String(format:) and never provides any
arguments. Therefore it fails to decode any string that contains a
% character. This changes it to call to String(_).
