### PR TITLE
splitAt does not behave like documented

### DIFF
--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -76,14 +76,14 @@ public func find<T>(list : [T], f : (T -> Bool)) -> T? {
 ///     splitAt(4, [1,2,3])     == ([1,2,3],[])
 ///     splitAt(0, [1,2,3])     == ([],[1,2,3])
 public func splitAt<T>(index : Int, list : [T]) -> ([T], [T]) {
-    switch index {
-    case 0..<list.count:
-        return (Array(list[0..<index]), Array(list[index..<list.count]))
-    case list.count...Int.max:
-        return (list, [T]())
-    default:
-        return ([T](), [T]())
-    }
+	switch index {
+	case 0..<list.count:
+		return (Array(list[0..<index]), Array(list[index..<list.count]))
+	case list.count...Int.max:
+		return (list, [T]())
+	default:
+		return ([T](), [T]())
+	}
 }
 
 /// Takes a separator and a list and intersperses that element throughout the list.

--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -80,7 +80,7 @@ public func splitAt<T>(index : Int, list : [T]) -> ([T], [T]) {
     case 0..<list.count:
         return (Array(list[0..<index]), Array(list[index..<list.count]))
     case list.count...Int.max:
-        return (Array(list[0..<list.count]), [T]())
+        return (list, [T]())
     default:
         return ([T](), [T]())
     }

--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -81,7 +81,7 @@ public func splitAt<T>(index : Int, list : [T]) -> ([T], [T]) {
         return (Array(list[0..<index]), Array(list[index..<list.count]))
     case list.count...Int.max:
         return (Array(list[0..<list.count]), [T]())
-    case _:
+    default:
         return ([T](), [T]())
     }
 }

--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -76,12 +76,14 @@ public func find<T>(list : [T], f : (T -> Bool)) -> T? {
 ///     splitAt(4, [1,2,3])     == ([1,2,3],[])
 ///     splitAt(0, [1,2,3])     == ([],[1,2,3])
 public func splitAt<T>(index : Int, list : [T]) -> ([T], [T]) {
-	switch index {
-	case 0..<list.count: 
-		return (Array(list[0..<index]), Array(list[index..<list.count]))
-	case _:
-		return ([T](), [T]())
-	}
+    switch index {
+    case 0..<list.count:
+        return (Array(list[0..<index]), Array(list[index..<list.count]))
+    case list.count...Int.max:
+        return (Array(list[0..<list.count]), [T]())
+    case _:
+        return ([T](), [T]())
+    }
 }
 
 /// Takes a separator and a list and intersperses that element throughout the list.

--- a/SwiftzTests/ArrayExtSpec.swift
+++ b/SwiftzTests/ArrayExtSpec.swift
@@ -70,15 +70,19 @@ class ArrayExtSpec : XCTestCase {
 			XCTAssert(found == 4, "Should be found")
 		}
 	}
-
+	
 	func testSplitAt() {
 		let withArray = [1,2,3,4]
 
 		let tuple = splitAt(2,withArray)
-
 		XCTAssert(tuple.0 == [1,2] && tuple.1 == [3,4], "Should be equal")
 
 		XCTAssert(splitAt(0,withArray).0 == Array() && splitAt(0, withArray).1 == [1,2,3,4], "Should be equal")
+		XCTAssert(splitAt(1,withArray).0 == [1] && splitAt(1, withArray).1 == [2,3,4], "Should be equal")
+		XCTAssert(splitAt(3,withArray).0 == [1,2,3] && splitAt(3, withArray).1 == [4], "Should be equal")
+		XCTAssert(splitAt(4,withArray).0 == [1,2,3,4] && splitAt(4, withArray).1 == Array(), "Should be equal")
+		XCTAssert(splitAt(5,withArray).0 == [1,2,3,4] && splitAt(5, withArray).1 == Array(), "Should be equal")
+		
 		XCTAssert(withArray == [1,2,3,4], "Should be equal(immutablility test)")
 	}
 


### PR DESCRIPTION
The documentation of `splitAt<T>(index : Int, list : [T]) -> ([T], [T])` in `ArrayExt.swift` gives this example:
`splitAt(4, [1,2,3])     == ([1,2,3],[])` which does not work with the current implementation. This PR tries to fix that.