### PR TITLE
Set Ops

### DIFF
--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -8,6 +8,52 @@
 
 /// MARK: Array extensions
 
+public enum ArrayMatcher<A> {
+	case Nil
+	case Cons(A, [A])
+}
+
+/// Destructures a list into its constituent parts.
+///
+/// If the given list is empty, this function returns .Empty.  If the list is non-empty, this
+/// function returns .Cons(hd, tl)
+public func match<T>(l : [T]) -> ArrayMatcher<T> {
+	if l.count == 0 {
+		return .Nil
+	} else if l.count == 1 {
+		return .Cons(l[0], [])
+	}
+	let hd = l[0]
+	let tl = Array<T>(l[1..<l.count])
+	return .Cons(hd, tl)
+}
+
+/// Returns the first element in the list, or None if the list is empty.
+public func head<A>(l : [A]) -> Optional<A> {
+	switch match(l) {
+	case .Nil:
+		return .None
+	case .Cons(let x, _):
+		return .Some(x)
+	}
+}
+
+/// Returns the tail of the list, or None if the list is empty.
+public func tail<A>(l : [A]) -> Optional<[A]> {
+	switch match(l) {
+	case .Nil:
+		return .None
+	case .Cons(_, let xs):
+		return .Some(xs)
+	}
+}
+
+/// Adds an element to the front of a list.
+public func cons<T>(lhs : T, var rhs : [T]) -> [T] {
+	rhs.insert(lhs, atIndex: 0)
+	return rhs
+}
+
 /// Safely indexes into an array by converting out of bounds errors to nils.
 public func safeIndex<T>(array : Array<T>)(i : Int) -> T? {
 	return indexArray(array, i)

--- a/Swiftz/Set.swift
+++ b/Swiftz/Set.swift
@@ -190,6 +190,16 @@ public struct Set<A : Hashable> {
 	public func reduce<B>(f : (B, A) -> B, initial : B) -> B {
 		return array.reduce(initial, combine: f)
 	}
+	
+	/// Returns all elements of the receiver in a List in no particular order.
+	public func toList() -> List<A> {
+		return self.reduce(flip(List.cons), initial: List())
+	}
+	
+	/// Returns all elements of the receiver in an Array in no particular order.
+	public func toArray() -> Array<A> {
+		return self.reduce(flip(cons), initial: [])
+	}
 }
 
 extension Set : ArrayLiteralConvertible {

--- a/Swiftz/Set.swift
+++ b/Swiftz/Set.swift
@@ -146,14 +146,20 @@ public struct Set<A : Hashable> {
 	}
 	
 	/// Returns the set of elements in the receiver that pass a given predicate.
-	public func filter(f : A -> Bool) -> Set<A> {
+	public func filter(p : A -> Bool) -> Set<A> {
 		var array = [A]()
 		for x in self {
-			if f(x) {
+			if p(x) {
 				array.append(x)
 			}
 		}
 		return Set(array: array)
+	}
+	
+	/// Partition the set into two sets, one with all elements that satisfy the predicate and one 
+	/// with all elements that don't satisfy the predicate.
+	public func partition(f : A -> Bool) -> (Set<A>, Set<A>) {
+		return (self.filter(f), self.filter({ !f($0) }))
 	}
 
 	/// Maps a function over the elements of the receiver and aggregates the result in a new set.
@@ -164,6 +170,16 @@ public struct Set<A : Hashable> {
 		}
 
 		return Set<B>(array: array)
+	}
+	
+	/// Applies a binary function to reduce the elements of the receiver to a single value.
+	public func reduce<B>(f : B -> A -> B, initial : B) -> B {
+		return array.reduce(initial, combine: uncurry(f))
+	}
+	
+	/// Applies a binary operator to reduce the elements of the receiver to a single value.
+	public func reduce<B>(f : (B, A) -> B, initial : B) -> B {
+		return array.reduce(initial, combine: f)
 	}
 }
 

--- a/Swiftz/Set.swift
+++ b/Swiftz/Set.swift
@@ -158,8 +158,17 @@ public struct Set<A : Hashable> {
 	
 	/// Partition the set into two sets, one with all elements that satisfy the predicate and one 
 	/// with all elements that don't satisfy the predicate.
-	public func partition(f : A -> Bool) -> (Set<A>, Set<A>) {
-		return (self.filter(f), self.filter({ !f($0) }))
+	public func partition(p : A -> Bool) -> (Set<A>, Set<A>) {
+		var satis = [A]()
+		var non = [A]()
+		for x in self {
+			if p(x) {
+				satis.append(x)
+			} else {
+				non.append(x)
+			}
+		}
+		return (Set(array: satis), Set(array: non))
 	}
 
 	/// Maps a function over the elements of the receiver and aggregates the result in a new set.

--- a/Swiftz/Set.swift
+++ b/Swiftz/Set.swift
@@ -11,9 +11,10 @@ import Darwin
 /// An immutable unordered sequence of distinct values.  Values are checked for uniqueness using 
 /// their hashes.
 public struct Set<A : Hashable> {
-	let bucket : Dictionary<A, Bool> = Dictionary()
+	private let bucket : Dictionary<A, Bool> = Dictionary()
 
-	var array : [A] {
+	/// Returns all elements of the receiver in an Array in no particular order.
+	public var toArray : [A] {
 		var arr = [A]()
 		for (key, _) in bucket {
 			arr.append(key)
@@ -21,6 +22,15 @@ public struct Set<A : Hashable> {
 		return arr
 	}
 
+	/// Returns all elements of the receiver in a List in no particular order.
+	public var toList : List<A> {
+		var list : List<A> = []
+		for (key, _) in bucket {
+			list = List(key, list)
+		}
+		return list
+	}
+	
 	public var count : Int {
 		return bucket.count
 	}
@@ -42,7 +52,7 @@ public struct Set<A : Hashable> {
 	///
 	/// If the receiver has no values this function will return nil.
 	public func any() -> A? {
-		let ar = self.array
+		let ar = self.toArray
 		if ar.isEmpty {
 			return nil
 		} else {
@@ -116,8 +126,8 @@ public struct Set<A : Hashable> {
 
 	/// Computes and returns the union of the reicever and a given set.
 	public func union(set : Set<A>) -> Set<A> {
-		var current = self.array
-		current += set.array
+		var current = self.toArray
+		current += set.toArray
 		return Set(array: current)
 	}
 
@@ -128,7 +138,7 @@ public struct Set<A : Hashable> {
 		if contains(item) {
 			return self
 		} else {
-			var arr = array
+			var arr = toArray
 			arr.append(item)
 			return Set(array:arr)
 		}
@@ -141,7 +151,7 @@ public struct Set<A : Hashable> {
 		if !contains(item) {
 			return self
 		} else {
-			return Set(array: array.filter { $0.hashValue != item.hashValue })
+			return Set(array: toArray.filter { $0.hashValue != item.hashValue })
 		}
 	}
 	
@@ -183,22 +193,12 @@ public struct Set<A : Hashable> {
 	
 	/// Applies a binary function to reduce the elements of the receiver to a single value.
 	public func reduce<B>(f : B -> A -> B, initial : B) -> B {
-		return array.reduce(initial, combine: uncurry(f))
+		return toArray.reduce(initial, combine: uncurry(f))
 	}
 	
 	/// Applies a binary operator to reduce the elements of the receiver to a single value.
 	public func reduce<B>(f : (B, A) -> B, initial : B) -> B {
-		return array.reduce(initial, combine: f)
-	}
-	
-	/// Returns all elements of the receiver in a List in no particular order.
-	public func toList() -> List<A> {
-		return self.reduce(flip(List.cons), initial: List())
-	}
-	
-	/// Returns all elements of the receiver in an Array in no particular order.
-	public func toArray() -> Array<A> {
-		return self.reduce(flip(cons), initial: [])
+		return toArray.reduce(initial, combine: f)
 	}
 }
 
@@ -212,7 +212,7 @@ extension Set : ArrayLiteralConvertible {
 
 extension Set : SequenceType {
 	public func generate() -> SetGenerator<A> {
-		let items = self.array
+		let items = self.toArray
 		return SetGenerator(items: items[0..<items.count])
 	}
 }
@@ -232,11 +232,11 @@ public struct SetGenerator<A> : GeneratorType {
 
 extension Set : Printable, DebugPrintable {
 	public var description: String {
-		return "\(self.array)"
+		return "\(self.toArray)"
 	}
 
 	public var debugDescription: String {
-		return "\(self.array)"
+		return "\(self.toArray)"
 	}
 }
 

--- a/Swiftz/Set.swift
+++ b/Swiftz/Set.swift
@@ -134,6 +134,17 @@ public struct Set<A : Hashable> {
 		}
 	}
 
+	/// Removes an item from the set.
+	///
+	/// If the item is not a member the receiver is returned unaltered.
+	public func remove(item : A) -> Set<A> {
+		if !contains(item) {
+			return self
+		} else {
+			return Set(array: array.filter { $0.hashValue != item.hashValue })
+		}
+	}
+	
 	/// Returns the set of elements in the receiver that pass a given predicate.
 	public func filter(f : A -> Bool) -> Set<A> {
 		var array = [A]()

--- a/SwiftzTests/SetTests.swift
+++ b/SwiftzTests/SetTests.swift
@@ -73,6 +73,18 @@ class SetTests: XCTestCase {
 		XCTAssert(newSet == Set(array: [4,5,6]), "Should be equal")
 	}
 	
+	func testPartition() {
+		let set = Set(array: [1,2,3,4,5,5,4,4,5,5])
+		let (s, n) = set.partition(>3)
+		XCTAssert(s == [4, 5], "Expected partitioned elements to be 4 and 5")
+		XCTAssert(n == [1, 2, 3], "Expected partitioned elements to be 1, 2, and 3")
+	}
+	
+	func testReduce() {
+		let set = Set<Int>(array: [1,2,3,4,5,5,4,4,5,5])
+		XCTAssert(set.reduce({ $0 + $1 }, initial: 0) == 15, "Expected reduction to yield sum.")
+	}
+	
 	func testIntersectsSet() {
 		let set = Set(array: [1,2,3,4,5,5,4,4,5,5])
 		XCTAssert(set.interectsSet(Set(arrayLiteral: 9,0,5)), "Should be true")

--- a/SwiftzTests/SetTests.swift
+++ b/SwiftzTests/SetTests.swift
@@ -18,6 +18,18 @@ class SetTests: XCTestCase {
 		XCTAssert(set.count == 5, "Should be 5 items")
 	}
 	
+	func testAdd() {
+		let set = Set(array:[1,2,3,4,4,4,5,5,5])
+		XCTAssert(set.add(5).count == 5, "Adding duplicate element changes nothing.")
+		XCTAssert(set.add(6).count == 6, "Adding unique element changes count")
+	}
+	
+	func testRemove() {
+		let set = Set(array:[1,2,3,4,4,4,5,5,5])
+		XCTAssert(set.remove(6).count == 5, "Removing unique element changes nothing.")
+		XCTAssert(set.remove(5).count == 4, "Removing member element changes count")
+	}
+	
 	func testEquality() {
 		var set1 = Set(array:[1,2,3,4,4,4,5,5,5])
 		var set2 = Set(array:[1,2,3,4,4,4,5,5,5])


### PR DESCRIPTION
- Adds `remove`, `reduce`, and `partition` to Set.
- Adds `toList()/toArray()` to Set.
- Moves head/tail/matcher machinery into an extension.

I wish these could be more efficient, but we'd need B-Trees underlying the thing and not a dictionary.