### PR TITLE
State Monad

### DIFF
--- a/Swiftz-iOS.xcodeproj/project.pbxproj
+++ b/Swiftz-iOS.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		84A88F7A1A70C7A0003D53CF /* TupleExtSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A88EDF1A70C707003D53CF /* TupleExtSpec.swift */; };
 		84A88F7B1A70C7A0003D53CF /* UserExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A88EE01A70C707003D53CF /* UserExample.swift */; };
 		84A8905C1A71E4C3003D53CF /* Swiftz.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 84A88D981A70C280003D53CF /* Swiftz.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		84BB57671AA12E4300214BC5 /* StateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BB57651AA12E3F00214BC5 /* StateSpec.swift */; };
 		84F2C4FC1A7AF34C00316E5F /* JSONKeypath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2C4FB1A7AF34C00316E5F /* JSONKeypath.swift */; };
 /* End PBXBuildFile section */
 
@@ -198,6 +199,7 @@
 		84A88EDE1A70C707003D53CF /* ThoseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ThoseSpec.swift; path = SwiftzTests/ThoseSpec.swift; sourceTree = SOURCE_ROOT; };
 		84A88EDF1A70C707003D53CF /* TupleExtSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TupleExtSpec.swift; path = SwiftzTests/TupleExtSpec.swift; sourceTree = SOURCE_ROOT; };
 		84A88EE01A70C707003D53CF /* UserExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserExample.swift; path = SwiftzTests/UserExample.swift; sourceTree = SOURCE_ROOT; };
+		84BB57651AA12E3F00214BC5 /* StateSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StateSpec.swift; path = SwiftzTests/StateSpec.swift; sourceTree = SOURCE_ROOT; };
 		84F2C4FB1A7AF34C00316E5F /* JSONKeypath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONKeypath.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -417,6 +419,7 @@
 				84A88ED61A70C707003D53CF /* MonoidSpec.swift */,
 				84A88EDA1A70C707003D53CF /* ResultSpec.swift */,
 				84A88EDB1A70C707003D53CF /* SetTests.swift */,
+				84BB57651AA12E3F00214BC5 /* StateSpec.swift */,
 				84A88EDE1A70C707003D53CF /* ThoseSpec.swift */,
 			);
 			name = Data;
@@ -536,6 +539,7 @@
 				84A88F6A1A70C7A0003D53CF /* EitherSpec.swift in Sources */,
 				84A88F6B1A70C7A0003D53CF /* FunctorSpec.swift in Sources */,
 				84A88F6C1A70C7A0003D53CF /* FutureSpec.swift in Sources */,
+				84BB57671AA12E4300214BC5 /* StateSpec.swift in Sources */,
 				84A88F6D1A70C7A0003D53CF /* HListSpec.swift in Sources */,
 				84A88F6E1A70C7A0003D53CF /* JSONSpec.swift in Sources */,
 				84A88F6F1A70C7A0003D53CF /* ListSpec.swift in Sources */,

--- a/Swiftz-iOS.xcodeproj/project.pbxproj
+++ b/Swiftz-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8480AB4C1A7B448300C6162D /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8480AB4B1A7B448300C6162D /* Sections.swift */; };
+		84961FB71A99917E004A186A /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84961FB61A99917E004A186A /* State.swift */; };
 		84A88D9D1A70C280003D53CF /* Swiftz.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A88D9C1A70C280003D53CF /* Swiftz.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84A88EF61A70C763003D53CF /* Swiftz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84A88D981A70C280003D53CF /* Swiftz.framework */; };
 		84A88EF71A70C77B003D53CF /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A88E8E1A70C649003D53CF /* Array.swift */; };
@@ -115,6 +116,7 @@
 
 /* Begin PBXFileReference section */
 		8480AB4B1A7B448300C6162D /* Sections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sections.swift; path = Carthage/Checkouts/Swiftx/Swiftx/Sections.swift; sourceTree = SOURCE_ROOT; };
+		84961FB61A99917E004A186A /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		84A88D5C1A70C23D003D53CF /* Swiftz-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Swiftz-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		84A88D621A70C23D003D53CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84A88D981A70C280003D53CF /* Swiftz.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftz.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -363,6 +365,7 @@
 				84A88DD81A70C2B5003D53CF /* Pointed.swift */,
 				84A88DDB1A70C2B5003D53CF /* Semigroup.swift */,
 				84A88DDC1A70C2B5003D53CF /* Set.swift */,
+				84961FB61A99917E004A186A /* State.swift */,
 				84A88DDF1A70C2B5003D53CF /* SYB.swift */,
 				84A88DE01A70C2B5003D53CF /* Those.swift */,
 				84A88DE11A70C2B5003D53CF /* Tuple.swift */,
@@ -612,6 +615,7 @@
 				84A88F2D1A70C77B003D53CF /* Tuple.swift in Sources */,
 				84F2C4FC1A7AF34C00316E5F /* JSONKeypath.swift in Sources */,
 				84A88F2E1A70C77B003D53CF /* TupleExt.swift in Sources */,
+				84961FB71A99917E004A186A /* State.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swiftz.xcodeproj/project.pbxproj
+++ b/Swiftz.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		84A8904D1A71DFE5003D53CF /* Nothing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A890431A71DFE5003D53CF /* Nothing.swift */; };
 		84A8904F1A71DFE5003D53CF /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A890451A71DFE5003D53CF /* Optional.swift */; };
 		84A890501A71DFE5003D53CF /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A890461A71DFE5003D53CF /* Result.swift */; };
+		84BB57641AA12D2200214BC5 /* StateSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BB57631AA12D2200214BC5 /* StateSpec.swift */; };
 		84F2C4FA1A7AEB9B00316E5F /* JSONKeypath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F2C4F91A7AEB9B00316E5F /* JSONKeypath.swift */; };
 /* End PBXBuildFile section */
 
@@ -198,6 +199,7 @@
 		84A890431A71DFE5003D53CF /* Nothing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Nothing.swift; path = Carthage/Checkouts/Swiftx/Swiftx/Nothing.swift; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 		84A890451A71DFE5003D53CF /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = Carthage/Checkouts/Swiftx/Swiftx/Optional.swift; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 		84A890461A71DFE5003D53CF /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Carthage/Checkouts/Swiftx/Swiftx/Result.swift; sourceTree = SOURCE_ROOT; usesTabs = 1; };
+		84BB57631AA12D2200214BC5 /* StateSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateSpec.swift; sourceTree = "<group>"; };
 		84F2C4F91A7AEB9B00316E5F /* JSONKeypath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONKeypath.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -417,6 +419,7 @@
 				84A88FBE1A71DFA0003D53CF /* MonoidSpec.swift */,
 				84A88FC21A71DFA0003D53CF /* ResultSpec.swift */,
 				84A88FC31A71DFA0003D53CF /* SetTests.swift */,
+				84BB57631AA12D2200214BC5 /* StateSpec.swift */,
 				84A88FC61A71DFA0003D53CF /* ThoseSpec.swift */,
 			);
 			name = Data;
@@ -601,6 +604,7 @@
 				84A88FDC1A71DFA0003D53CF /* TupleExtSpec.swift in Sources */,
 				84A88FCB1A71DFA0003D53CF /* ConcurrentTests.swift in Sources */,
 				84A88FD61A71DFA0003D53CF /* PartyExample.swift in Sources */,
+				84BB57641AA12D2200214BC5 /* StateSpec.swift in Sources */,
 				84A88FCF1A71DFA0003D53CF /* HListSpec.swift in Sources */,
 				84A88FDB1A71DFA0003D53CF /* ThoseSpec.swift in Sources */,
 				84A88FDD1A71DFA0003D53CF /* UserExample.swift in Sources */,

--- a/Swiftz.xcodeproj/project.pbxproj
+++ b/Swiftz.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		84152B731A818A5C006387D5 /* Swiftz.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 84A88F981A71DF7F003D53CF /* Swiftz.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8480AB4E1A7B448A00C6162D /* Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8480AB4D1A7B448A00C6162D /* Sections.swift */; };
+		84961FB51A998976004A186A /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84961FB41A998976004A186A /* State.swift */; };
 		84A88F9E1A71DF7F003D53CF /* Swiftz.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A88F9D1A71DF7F003D53CF /* Swiftz.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84A88FA41A71DF7F003D53CF /* Swiftz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84A88F981A71DF7F003D53CF /* Swiftz.framework */; };
 		84A88FC91A71DFA0003D53CF /* ArrayExtSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A88FB41A71DFA0003D53CF /* ArrayExtSpec.swift */; };
@@ -115,6 +116,7 @@
 
 /* Begin PBXFileReference section */
 		8480AB4D1A7B448A00C6162D /* Sections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sections.swift; path = Carthage/Checkouts/Swiftx/Swiftx/Sections.swift; sourceTree = SOURCE_ROOT; };
+		84961FB41A998976004A186A /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		84A88F981A71DF7F003D53CF /* Swiftz.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Swiftz.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		84A88F9C1A71DF7F003D53CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84A88F9D1A71DF7F003D53CF /* Swiftz.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Swiftz.h; path = Swiftz/Swiftz.h; sourceTree = "<group>"; };
@@ -363,6 +365,7 @@
 				84A890041A71DFC5003D53CF /* Pointed.swift */,
 				84A890071A71DFC5003D53CF /* Semigroup.swift */,
 				84A890081A71DFC5003D53CF /* Set.swift */,
+				84961FB41A998976004A186A /* State.swift */,
 				84A8900A1A71DFC5003D53CF /* SYB.swift */,
 				84A8900B1A71DFC5003D53CF /* Those.swift */,
 				84A8900C1A71DFC5003D53CF /* Tuple.swift */,
@@ -584,6 +587,7 @@
 				84A890171A71DFC5003D53CF /* Comonad.swift in Sources */,
 				84F2C4FA1A7AEB9B00316E5F /* JSONKeypath.swift in Sources */,
 				84A8901F1A71DFC5003D53CF /* GCDExecutionContext.swift in Sources */,
+				84961FB51A998976004A186A /* State.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Swiftz/IxState.swift
+++ b/Swiftz/IxState.swift
@@ -8,38 +8,44 @@
 
 
 public struct IxState<I, O, A> {
-	let run: I -> (A, O)
+	let run : I -> (A, O)
 
-	public init(_ run: I -> (A, O)) {
+	public init(_ run : I -> (A, O)) {
 		self.run = run
 	}
 
-	public func eval(s: I) -> A {
+	public func eval(s : I) -> A {
 		return run(s).0
 	}
 
-	public func exec(s: I) -> O {
+	public func exec(s : I) -> O {
 		return run(s).1
 	}
 
-	public func map<B>(f: A -> B) -> IxState<I, O, B> {
+	public func map<B>(f : A -> B) -> IxState<I, O, B> {
 		return f <^> self
 	}
 
-	public func contramap<H>(f: H -> I) -> IxState<H, O, A> {
+	public func contramap<H>(f : H -> I) -> IxState<H, O, A> {
 		return f <!> self
 	}
 
-	public func imap<P>(f: O -> P) -> IxState<I, P, A> {
+	public func imap<P>(f : O -> P) -> IxState<I, P, A> {
 		return f <^^> self
 	}
 
-	public func ap<E, B>(f: IxState<E, I, A -> B>) -> IxState<E, O, B> {
+	public func ap<E, B>(f : IxState<E, I, A -> B>) -> IxState<E, O, B> {
 		return f <*> self
 	}
 
-	public func flatMap<E, B>(f: A -> IxState<O, E, B>) -> IxState<I, E, B> {
+	public func flatMap<E, B>(f : A -> IxState<O, E, B>) -> IxState<I, E, B> {
 		return self >>- f
+	}
+	
+	/// Converts an Indexed State Monad to a plain State Monad.  Provide `identity` to the evidence
+	/// parameter.
+	public func toState(evidence : IxState<I, O, A> -> IxState<O, O, A>) -> State<O, A> {
+		return State<O, A>(evidence(self).run)
 	}
 }
 

--- a/Swiftz/Pointed.swift
+++ b/Swiftz/Pointed.swift
@@ -39,3 +39,9 @@ extension Set : Pointed {
 		return Set(arrayLiteral: x)
 	}
 }
+
+extension State : Pointed {
+	public static func pure(x : A) -> State<S, A> {
+		return State({ s in (x, s) })
+	}
+}

--- a/Swiftz/Pointed.swift
+++ b/Swiftz/Pointed.swift
@@ -39,9 +39,3 @@ extension Set : Pointed {
 		return Set(arrayLiteral: x)
 	}
 }
-
-extension State : Pointed {
-	public static func pure(x : A) -> State<S, A> {
-		return State({ s in (x, s) })
-	}
-}

--- a/Swiftz/State.swift
+++ b/Swiftz/State.swift
@@ -1,0 +1,90 @@
+//
+//  State.swift
+//  Swiftz
+//
+//  Created by Robert Widmann on 2/21/15.
+//  Copyright (c) 2015 TypeLift. All rights reserved.
+//
+
+/// The State Monad represents a computation that threads a piece of state through each step.
+public struct State<S, A> {
+	public let runState : S -> (A, S)
+	
+	/// Creates a new State Monad given a function from a piece of state to a value and an updated
+	/// state.
+	public init(_ runState : S -> (A, S)) {
+		self.runState = runState
+	}
+	
+	/// Evaluates the computation given an initial state then returns a final value after running
+	/// each step.
+	public func eval(s : S) -> A {
+		return self.runState(s).0
+	}
+	
+	/// Evaluates the computation given an initial state then returns the final state after running
+	/// each step.
+	public func exec(s : S) -> S {
+		return self.runState(s).1
+	}
+	
+	/// Executes an action that can modify the inner state.
+	public func withState(f : S -> S) -> State<S, A> {
+		return State(self.runState • f)
+	}
+}
+
+extension State : Functor {
+	typealias B = Swift.Any
+	typealias FB = State<S, B>
+	
+	public func fmap<B>(f : A -> B) -> State<S, B> {
+		return State<S, B>({ s in
+			let (val, st2) = self.runState(s)
+			return (f(val), st2)
+		})
+	}
+}
+
+/// Fetches the current value of the state.
+public func get<S>() -> State<S, S> {
+	return State<S, S> { ($0, $0) }
+}
+
+/// Sets the state.
+public func put<S>(s : S) -> State<S, ()> {
+	return State<S, ()> { _ in ((), s) }
+}
+
+/// Gets a specific component of the state using a projection function.
+public func gets<S, A>(f : S -> A) -> State<S, A> {
+	return State { s in (f(s), s) }
+}
+
+/// Updates the state with the result of executing the given function. 
+public func modify<S>(f : S -> S) -> State<S, ()> {
+	return State<S, ()> { s in ((), f(s)) }
+}
+
+// Uncomment to crash Swiftc
+// - Fixed in 1.2; TODO: Uncomment in #181
+//extension State : Applicative {
+//	typealias FAB = State<S, A -> B>
+//	
+//	public func ap<B>(stfn : State<S, A -> B>) -> State<S, B> {
+//		return stfn.bind({ f in
+//			return self.bind({ a in
+//				return State<S, B>.pure(f(a))
+//			})
+//		})
+//	}
+//}
+//
+//extension State : Monad {
+//	public func bind<B>(f : A -> State<S, B>) -> State<S, B> {
+//		return State<S, B>({ s in
+//			let (a, s2) = self.runState(s)
+//			return f(a).runState(s2)
+//		})
+//	}
+//}

--- a/Swiftz/State.swift
+++ b/Swiftz/State.swift
@@ -71,6 +71,12 @@ public func modify<S>(f : S -> S) -> State<S, ()> {
 	return State<S, ()> { s in ((), f(s)) }
 }
 
+extension State : Pointed {
+	public static func pure(x : A) -> State<S, A> {
+		return State({ s in (x, s) })
+	}
+}
+
 // Uncomment to crash Swiftc
 // - Fixed in 1.2; TODO: Uncomment in #181
 //extension State : Applicative {

--- a/Swiftz/State.swift
+++ b/Swiftz/State.swift
@@ -32,6 +32,11 @@ public struct State<S, A> {
 	public func withState(f : S -> S) -> State<S, A> {
 		return State(self.runState • f)
 	}
+	
+	/// Converts a State Monad to an Indexed State Monad.
+	public func toIndexedState() -> IxState<S, S, A> {
+		return IxState(runState)
+	}
 }
 
 extension State : Functor {

--- a/SwiftzTests/StateSpec.swift
+++ b/SwiftzTests/StateSpec.swift
@@ -1,0 +1,21 @@
+//
+//  StateSpec.swift
+//  Swiftz
+//
+//  Created by Robert Widmann on 2/27/15.
+//  Copyright (c) 2015 TypeLift. All rights reserved.
+//
+
+import XCTest
+import Swiftz
+
+class StateSpec : XCTestCase {
+	func testStateConversion() {
+		let ixState : IxState<String, String, Int> = pure(5)
+		let state : State<String, Int> = State.pure(5)
+		
+		XCTAssertTrue(ixState.eval("") == state.eval(""), "Expected state monads to have the same value")
+		XCTAssertTrue(ixState.toState(identity).eval("") == state.eval(""), "Expected conversion to succeed")
+		XCTAssertTrue(state.toIndexedState().eval("") == ixState.eval(""), "Expected conversion to succeed")
+	}
+}


### PR DESCRIPTION
Adds the plain (and currently utterly useless) State monad.

Swift 1.1 is not a fan of the Monad instance.