### PR TITLE
Fix List Equality

### DIFF
--- a/Swiftz/List.swift
+++ b/Swiftz/List.swift
@@ -531,7 +531,7 @@ public func == <A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {
 		return false
 	}
 	
-	return lazy(Zip2Sequence(lhs, rhs)).map(==).reduce(true) { $0 && $1 }
+	return zip(lhs, rhs).map(==).reduce(true) { $0 && $1 }
 }
 
 public func != <A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {

--- a/Swiftz/List.swift
+++ b/Swiftz/List.swift
@@ -523,14 +523,15 @@ public func + <A>(lhs : List<A>, rhs : List<A>) -> List<A> {
 /// MARK: Equatable
 
 public func == <A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {
-	switch (lhs.match, rhs.match) {
-	case (.Nil, .Nil):
-		return true
-	case let (.Cons(lHead, lTail), .Cons(rHead, rTail)):
-		return lHead == rHead && lTail == rTail
-	default:
+	if !lhs.isFinite || !rhs.isFinite {
+		return error("Fatal: One of the lists being compared for equality is not finite.")
+	}
+	
+	if lhs.count != rhs.count {
 		return false
 	}
+	
+	return lazy(Zip2Sequence(lhs, rhs)).map(==).reduce(true) { $0 && $1 }
 }
 
 public func != <A : Equatable>(lhs : List<A>, rhs : List<A>) -> Bool {
@@ -580,6 +581,8 @@ public final class ListGenerator<A> : GeneratorType {
 }
 
 extension List : SequenceType {
+	typealias Generator = ListGenerator<A>
+
 	public func generate() -> ListGenerator<A> {
 		return ListGenerator(self)
 	}

--- a/Swiftz/NonEmptyList.swift
+++ b/Swiftz/NonEmptyList.swift
@@ -36,8 +36,12 @@ public struct NonEmptyList<A> {
 	}
 }
 
-public func ==<A : Equatable>(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> Bool {
-	return (lhs.head == rhs.head && lhs.tail == rhs.tail)
+public func == <A : Equatable>(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> Bool {
+	return lhs.toList() == rhs.toList()
+}
+
+public func != <A : Equatable>(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> Bool {
+	return lhs.toList() != rhs.toList()
 }
 
 extension NonEmptyList : ArrayLiteralConvertible {
@@ -59,6 +63,8 @@ extension NonEmptyList : ArrayLiteralConvertible {
 }
 
 extension NonEmptyList : SequenceType {
+	typealias Generator = ListGenerator<A>
+	
 	public func generate() -> ListGenerator<A> {
 		return ListGenerator(self.toList())
 	}

--- a/SwiftzTests/ListSpec.swift
+++ b/SwiftzTests/ListSpec.swift
@@ -66,26 +66,30 @@ class ListSpec : XCTestCase {
 			return (List.pure(identity) <*> x) == x
 		}
 
-		// Swift unroller can't handle our scale.
-//		property("List obeys the first Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
-//			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
-//				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
-//					let f = fl.fmap({ $0.getArrow })
-//					let g = gl.fmap({ $0.getArrow })
-//					return (curry(•) <^> f <*> g <*> x) == (f <*> (g <*> x))
-//				}
-//			}
-//		}
-//		
-//		property("List obeys the second Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
-//			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
-//				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
-//					let f = fl.fmap({ $0.getArrow })
-//					let g = gl.fmap({ $0.getArrow })
-//					return (List.pure(curry(•)) <*> f <*> g <*> x) == (f <*> (g <*> x))
-//				}
-//			}
-//		}
+		// Swift unroller can't handle our scale; Use only small lists.
+		property("List obeys the first Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
+			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
+				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
+					return (fl.count <= 3 && gl.count <= 3) ==> {
+						let f = fl.fmap({ $0.getArrow })
+						let g = gl.fmap({ $0.getArrow })
+						return (curry(•) <^> f <*> g <*> x) == (f <*> (g <*> x))
+					}
+				}
+			}
+		}
+
+		property("List obeys the second Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
+			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
+				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
+					return (fl.count <= 3 && gl.count <= 3) ==> {
+						let f = fl.fmap({ $0.getArrow })
+						let g = gl.fmap({ $0.getArrow })
+						return (List.pure(curry(•)) <*> f <*> g <*> x) == (f <*> (g <*> x))
+					}
+				}
+			}
+		}
 
 		property("List obeys the Monoidal left identity law") <- forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
 			return (x <> List()) == x

--- a/SwiftzTests/ListSpec.swift
+++ b/SwiftzTests/ListSpec.swift
@@ -67,16 +67,24 @@ class ListSpec : XCTestCase {
 		}
 
 		// Swift unroller can't handle our scale.
-//		property("List obeys the first Applicative composition law") <- forAll { (fl : ListOf<ArrowOf<Int8, Int8>>, gl : ListOf<ArrowOf<Int8, Int8>>, x : ListOf<Int8>) in
-//			let f = fl.getList.fmap({ $0.getArrow })
-//			let g = gl.getList.fmap({ $0.getArrow })
-//			return (curry(•) <^> f <*> g <*> x.getList) == (f <*> (g <*> x.getList))
+//		property("List obeys the first Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
+//			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
+//				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
+//					let f = fl.fmap({ $0.getArrow })
+//					let g = gl.fmap({ $0.getArrow })
+//					return (curry(•) <^> f <*> g <*> x) == (f <*> (g <*> x))
+//				}
+//			}
 //		}
-//
-//		property("List obeys the second Applicative composition law") <- forAll { (fl : ListOf<ArrowOf<Int8, Int8>>, gl : ListOf<ArrowOf<Int8, Int8>>, x : ListOf<Int8>) in
-//			let f = fl.getList.fmap({ $0.getArrow })
-//			let g = gl.getList.fmap({ $0.getArrow })
-//			return (List.pure(curry(•)) <*> f <*> g <*> x.getList) == (f <*> (g <*> x.getList))
+//		
+//		property("List obeys the second Applicative composition law") <- forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { fl in
+//			return forAllShrink(List<ArrowOf<Int8, Int8>>.arbitrary, shrinker: List.shrink) { gl in
+//				return forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in
+//					let f = fl.fmap({ $0.getArrow })
+//					let g = gl.fmap({ $0.getArrow })
+//					return (List.pure(curry(•)) <*> f <*> g <*> x) == (f <*> (g <*> x))
+//				}
+//			}
 //		}
 
 		property("List obeys the Monoidal left identity law") <- forAllShrink(List<Int8>.arbitrary, shrinker: List<Int8>.shrink) { x in

--- a/SwiftzTests/NonEmptyListSpec.swift
+++ b/SwiftzTests/NonEmptyListSpec.swift
@@ -24,6 +24,35 @@ extension NonEmptyList where A : Arbitrary {
 
 class NonEmptyListSpec : XCTestCase {
 	func testProperties() {
+		property("Non-empty Lists of Equatable elements obey reflexivity") <- forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { l in
+			return l == l
+		}
+		
+		property("Non-empty Lists of Equatable elements obey symmetry") <- forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { x in
+			return forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { y in
+				return (x == y) == (y == x)
+			}
+		}
+		
+		property("Non-empty Lists of Equatable elements obey transitivity") <- forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { x in
+			return forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { y in
+				let inner = forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { z in
+					return (x == y) && (y == z) ==> (x == z)
+				}
+				return inner
+			}
+		}
+		
+		property("Non-empty Lists of Equatable elements obey negation") <- forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { x in
+			return forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { y in
+				return (x != y) == !(x == y)
+			}
+		}
+		
+		property("Non-empty Lists of Comparable elements obey reflexivity") <- forAllShrink(NonEmptyList<Int>.arbitrary, shrinker: NonEmptyList<Int>.shrink) { l in
+			return l == l
+		}
+		
 		property("head behaves") <- forAll { (x : Int) in
 			return forAllShrink(List<Int>.arbitrary, shrinker: List<Int>.shrink) { xs in
 				return NonEmptyList(x, xs).head == x


### PR DESCRIPTION
The old recursive definition, while clever, was wasteful.. This definition is not only far, far, *far*, quicker, but short-circuiting and handles infinite lists.