### PR TITLE
Lowered iOS deployment target to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Operator | Name           | Type
 System Requirements
 ===================
 
-Swiftz supports OS X 10.9+ and iOS 7.0+.
+Swiftz supports OS X 10.9+ and iOS 8.0+.
 
 License
 =======

--- a/Swiftz.xcodeproj/project.pbxproj
+++ b/Swiftz.xcodeproj/project.pbxproj
@@ -1124,7 +1124,7 @@
 				);
 				INFOPLIST_FILE = Swiftz/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typelift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Swiftz;
@@ -1147,7 +1147,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = Swiftz/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.typelift.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Swiftz;


### PR DESCRIPTION
The `iOS` framework still compiles, so I imagine there was no reason for this to be 8.3 :)