### PR TITLE
Added <?? optional retrieve for JSON serialization of optional parameters

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
 github "typelift/Swiftx"
 github "typelift/SwiftCheck"
-github "typelift/Operadics"
+github "typelift/Operadics" "master"
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "typelift/Operadics" "0.1.4"
+github "typelift/Operadics" "ade8db262ea0b3daee35b2cf0573a11b0bb0c2a3"
 github "typelift/SwiftCheck" "v0.3.2"
 github "typelift/Swiftx" "v0.3.1"

--- a/Swiftz/JSON.swift
+++ b/Swiftz/JSON.swift
@@ -168,6 +168,18 @@ public func <? <A : JSONDecodable where A == A.J>(lhs : JSONValue, rhs : JSONKey
 	}
 }
 
+public func <?? <A : JSONDecodable where A == A.J>(lhs : JSONValue, rhs : JSONKeypath) -> A?? {
+	return lhs <? rhs ?? nil
+}
+
+public func <?? <A : JSONDecodable where A == A.J>(lhs : JSONValue, rhs : JSONKeypath) -> [A]?? {
+	return lhs <? rhs ?? nil
+}
+
+public func <?? <A : JSONDecodable where A == A.J>(lhs : JSONValue, rhs : JSONKeypath) -> [String: A]?? {
+	return lhs <? rhs ?? nil
+}
+
 public func <! <A : JSONDecodable where A == A.J>(lhs : JSONValue, rhs : JSONKeypath) -> A {
 	if let r : A = (lhs <? rhs) {
 		return r

--- a/Swiftz/JSON.swift
+++ b/Swiftz/JSON.swift
@@ -8,12 +8,6 @@
 
 import Foundation
 
-/// Temporarily added <?? parameter until <?? is added to Operadics.
-infix operator <?? {
-    associativity left
-    precedence 150
-}
-
 public enum JSONValue : CustomStringConvertible {
 	case JSONArray([JSONValue])
 	case JSONObject(Dictionary<String, JSONValue>)

--- a/Swiftz/JSON.swift
+++ b/Swiftz/JSON.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+/// Temporarily added <?? parameter until <?? is added to Operadics.
+infix operator <?? {
+    associativity left
+    precedence 150
+}
+
 public enum JSONValue : CustomStringConvertible {
 	case JSONArray([JSONValue])
 	case JSONObject(Dictionary<String, JSONValue>)

--- a/SwiftzTests/JSONSpec.swift
+++ b/SwiftzTests/JSONSpec.swift
@@ -295,17 +295,17 @@ extension JSONSpec {
 	}
 }
 
-struct TestObject: JSONDecodable {
-	let required1: String
-	let required2: String
-	let optional1: Bool?
-	let optional2: Bool?
+struct TestObject : JSONDecodable {
+	let required1 : String
+	let required2 : String
+	let optional1 : Bool?
+	let optional2 : Bool?
 	
 	static func fromJSON(x : JSONValue) -> TestObject? {
-		let p1: String? = x <? "required1"
-		let p2: String? = x <? "required2"
-		let p3: Bool?? = x <?? "optional1"
-		let p4: Bool?? = x <?? "optional2"
+		let p1 : String? = x <? "required1"
+		let p2 : String? = x <? "required2"
+		let p3 : Bool?? = x <?? "optional1"
+		let p4 : Bool?? = x <?? "optional2"
 		
 		return curry(TestObject.init)
 			<^> p1

--- a/SwiftzTests/JSONSpec.swift
+++ b/SwiftzTests/JSONSpec.swift
@@ -294,3 +294,60 @@ extension JSONSpec {
 		XCTAssertTrue(badCoord == nil)
 	}
 }
+
+struct TestObject: JSONDecodable {
+	let required1: String
+	let required2: String
+	let optional1: Bool?
+	let optional2: Bool?
+	
+	static func fromJSON(x : JSONValue) -> TestObject? {
+		let p1: String? = x <? "required1"
+		let p2: String? = x <? "required2"
+		let p3: Bool?? = x <?? "optional1"
+		let p4: Bool?? = x <?? "optional2"
+		
+		return curry(TestObject.init)
+			<^> p1
+			<*> p2
+			<*> p3
+			<*> p4
+	}
+}
+
+extension JSONSpec {
+	func testOptionalRetrieve() {
+		let jsonWithOptionalValue1 = "{\"required1\":\"a\", \"required2\":\"b\",\"optional1\":false}"
+		let jsonWithOptionalValue2 = "{\"required1\":\"a\", \"required2\":\"b\",\"optional2\":true}"
+		let jsonWithOptionalValue3 = "{\"required1\":\"a\", \"required2\":\"b\",\"optional1\":true,\"optional2\":false}"
+		let jsonWithoutOptionalValues = "{\"required1\":\"a\", \"required2\":\"b\"}"
+		
+		let testObject1 = JSONValue.decode(jsonWithOptionalValue1) >>- TestObject.fromJSON
+		XCTAssertNotNil(testObject1)
+		XCTAssert(testObject1!.required1 == "a")
+		XCTAssert(testObject1!.required2 == "b")
+		XCTAssert(testObject1!.optional1 == false)
+		XCTAssert(testObject1!.optional2 == nil)
+		
+		let testObject2 = JSONValue.decode(jsonWithOptionalValue2) >>- TestObject.fromJSON
+		XCTAssertNotNil(testObject2)
+		XCTAssert(testObject2!.required1 == "a")
+		XCTAssert(testObject2!.required2 == "b")
+		XCTAssert(testObject2!.optional1 == nil)
+		XCTAssert(testObject2!.optional2 == true)
+		
+		let testObject3 = JSONValue.decode(jsonWithOptionalValue3) >>- TestObject.fromJSON
+		XCTAssertNotNil(testObject3)
+		XCTAssert(testObject3!.required1 == "a")
+		XCTAssert(testObject3!.required2 == "b")
+		XCTAssert(testObject3!.optional1 == true)
+		XCTAssert(testObject3!.optional2 == false)
+		
+		let testObject4 = JSONValue.decode(jsonWithoutOptionalValues) >>- TestObject.fromJSON
+		XCTAssertNotNil(testObject4)
+		XCTAssert(testObject4!.required1 == "a")
+		XCTAssert(testObject4!.required2 == "b")
+		XCTAssert(testObject4!.optional1 == nil)
+		XCTAssert(testObject4!.optional2 == nil)
+	}
+}


### PR DESCRIPTION
Note: The definition of operator <?? is in Operadics. The operator definition was temporarily added to JSON.swift to satisfy the requirement until the PR in Operadics is merged.

See: https://github.com/typelift/Operadics/pull/4