### PR TITLE
Added support for JSONDecodable and JSONEncodable for NSDate

### DIFF
--- a/Swiftz/JSON.swift
+++ b/Swiftz/JSON.swift
@@ -342,6 +342,21 @@ extension String : JSON {
 	}
 }
 
+extension NSDate : JSON {
+	public static func fromJSON(x : JSONValue) -> NSDate? {
+		switch x {
+		case .JSONNumber(let value):
+			return NSDate(timeIntervalSince1970: value.doubleValue / 1000.0)
+		default:
+			return nil
+		}
+	}
+	
+	public static func toJSON(date: NSDate) -> JSONValue {
+		return JSONValue.JSONNumber(date.timeIntervalSince1970 * 1000.0)
+	}
+}
+
 // or unit...
 extension NSNull : JSON {
 	public class func fromJSON(x : JSONValue) -> NSNull? {

--- a/SwiftzTests/JSONSpec.swift
+++ b/SwiftzTests/JSONSpec.swift
@@ -415,3 +415,23 @@ extension JSONSpec {
 		XCTAssert("{\"accessLevel\":1,\"userRole\":\"admin\"}" == jsonString)
 	}
 }
+
+struct UserAccessLog: JSONDecodable {
+	let lastUpdated: NSDate
+	
+	static func fromJSON(x : JSONValue) -> UserAccessLog? {
+		let p1 : NSDate? = x <? "lastUpdated"
+		return UserAccessLog.init <^> p1
+	}
+}
+
+extension JSONSpec {
+	func testDateJSONDecodable() {
+		let timestampInMilliseconds: Double = 1443769200000
+		let date = NSDate(timeIntervalSince1970: timestampInMilliseconds / 1000.0)
+		let json = "{\"lastUpdated\":\(timestampInMilliseconds)}"
+		let userAccessLog = JSONValue.decode(json) >>- UserAccessLog.fromJSON
+		XCTAssertNotNil(userAccessLog)
+		XCTAssert(userAccessLog?.lastUpdated == date)
+	}
+}


### PR DESCRIPTION
It will work when the date in json is expressed as a millisecond timestamp number.