### PR TITLE
Stop building test target on Run and Analyze action

### DIFF
--- a/Swiftz.xcodeproj/xcshareddata/xcschemes/Swiftz-iOS.xcscheme
+++ b/Swiftz.xcodeproj/xcshareddata/xcschemes/Swiftz-iOS.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "84DF75271B0BD17700C912B0"

--- a/Swiftz.xcodeproj/xcshareddata/xcschemes/Swiftz.xcscheme
+++ b/Swiftz.xcodeproj/xcshareddata/xcschemes/Swiftz.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "84A88FA21A71DF7F003D53CF"


### PR DESCRIPTION
https://github.com/typelift/Swiftz/pull/288#issuecomment-165232231:

> Not sure why it worked on Travis, but not through Carthage. This should fix it. I can confirm it's fixed locally when pointing to my branch.

That is because the test target were also built when Carthage builds the scheme because of `buildForRunning = "YES"` of the test target. Carthage uses Release configuration to build by default in which `ENABLE_TESTABILITY` is NO. Thus, `@testable import` breaks the build.

See also Carthage/Carthage#517. Additionally, those are disabled by default in a fresh target created by Xcode 7.2.
