### PR TITLE
Add sequence functions for various monads

### DIFF
--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -518,3 +518,13 @@ public func intercalate<A>(list : [A], nested : [[A]]) -> [A] {
 public func concat<T>(list : [[T]]) -> [T] {
 	return list.reduce([], combine: +)
 }
+
+public func sequence<A>(ms: [Array<A>]) -> Array<[A]> {
+	return ms.reduce(Array<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Array<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -520,6 +520,8 @@ public func concat<T>(list : [[T]]) -> [T] {
 }
 
 public func sequence<A>(ms: [Array<A>]) -> Array<[A]> {
+	if ms.isEmpty { return [] }
+	
 	return ms.reduce(Array<[A]>.pure([]), combine: { n, m in
 		return n.bind { xs in
 			return m.bind { x in

--- a/Swiftz/EitherExt.swift
+++ b/Swiftz/EitherExt.swift
@@ -130,3 +130,13 @@ extension Either : Foldable {
 		}
 	}
 }
+
+public func sequence<L, R>(ms: [Either<L, R>]) -> Either<L, [R]> {
+	return ms.reduce(Either<L, [R]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Either<L, [R]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/Identity.swift
+++ b/Swiftz/Identity.swift
@@ -143,3 +143,13 @@ extension Identity : Comonad {
 		return self.duplicate().fmap(f)
 	}
 }
+
+public func sequence<A>(ms: [Identity<A>]) -> Identity<[A]> {
+	return ms.reduce(Identity<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Identity<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/List.swift
+++ b/Swiftz/List.swift
@@ -700,3 +700,13 @@ extension List : MonadPlus {
 		return self + other
 	}
 }
+
+public func sequence<A>(ms: [List<A>]) -> List<[A]> {
+	return ms.reduce(List<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return List<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/OptionalExt.swift
+++ b/Swiftz/OptionalExt.swift
@@ -144,6 +144,16 @@ extension Optional : SequenceType {
 	}
 }
 
+public func sequence<A>(ms: [Optional<A>]) -> Optional<[A]> {
+	return ms.reduce(Optional<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Optional<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}
+
 /// Forbidden by Swift 1.2; see ~( http://stackoverflow.com/a/29750368/945847 ))
 /// Given one or more Optional values, returns the first Optional value that is not nil
 /// when evaulated from left to right

--- a/Swiftz/Proxy.swift
+++ b/Swiftz/Proxy.swift
@@ -171,3 +171,14 @@ extension Proxy : Comonad {
 public func asProxyTypeOf<T>(x : T, _ proxy : Proxy<T>) -> T {
 	return const(x)(proxy)
 }
+
+public func sequence<A>(ms: [Proxy<A>]) -> Proxy<[A]> {
+	return ms.reduce(Proxy<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Proxy<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}
+

--- a/Swiftz/Reader.swift
+++ b/Swiftz/Reader.swift
@@ -135,3 +135,14 @@ public func >>->> <R, A, B, C>(f : A -> Reader<R, B>, g : B -> Reader<R, C>) -> 
 public func <<-<< <R, A, B, C>(g : B -> Reader<R, C>, f : A -> Reader<R, B>) -> (A -> Reader<R, C>) {
     return f >>->> g
 }
+
+// Can't get this to type check.
+//public func sequence<R, A>(ms: [Reader<R, A>]) -> Reader<R, [A]> {
+//    return ms.reduce(Reader<R, [A]>.pure([]), combine: { n, m in
+//        return n.bind { xs in
+//            return  m.bind { x in
+//                return Reader<R, [A]>.pure(xs + [x])
+//            }
+//        }
+//    })
+//}

--- a/Swiftz/State.swift
+++ b/Swiftz/State.swift
@@ -146,3 +146,13 @@ public func >>->> <S, A, B, C>(f : A -> State<S, B>, g : B -> State<S, C>) -> (A
 public func <<-<< <S, A, B, C>(g : B -> State<S, C>, f : A -> State<S, B>) -> (A -> State<S, C>) {
 	return f >>->> g
 }
+
+public func sequence<S, A>(ms: [State<S, A>]) -> State<S, [A]> {
+	return ms.reduce(State<S, [A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return State<S, [A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/Stream.swift
+++ b/Swiftz/Stream.swift
@@ -335,3 +335,13 @@ extension Stream : CustomStringConvertible {
 		return "[\(self.head), ...]"
 	}
 }
+
+public func sequence<A>(ms: [Stream<A>]) -> Stream<[A]> {
+	return ms.reduce(Stream<[A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Stream<[A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/Swiftz/StringExt.swift
+++ b/Swiftz/StringExt.swift
@@ -206,3 +206,8 @@ extension String : Monad {
 public func >>- (l : String, f : Character -> String) -> String {
 	return l.bind(f)
 }
+
+public func sequence(ms: [String]) -> [String] {
+	return sequence(ms.map { m in Array(m.characters) }).map(String.init)
+}
+

--- a/Swiftz/Writer.swift
+++ b/Swiftz/Writer.swift
@@ -158,3 +158,12 @@ public func != <W : protocol<Monoid, Equatable>, A : Equatable>(l : Writer<W, A>
 	return !(l == r)
 }
 
+public func sequence<W, A>(ms: [Writer<W, A>]) -> Writer<W, [A]> {
+	return ms.reduce(Writer<W, [A]>.pure([]), combine: { n, m in
+		return n.bind { xs in
+			return m.bind { x in
+				return Writer<W, [A]>.pure(xs + [x])
+			}
+		}
+	})
+}

--- a/SwiftzTests/ArrayExtSpec.swift
+++ b/SwiftzTests/ArrayExtSpec.swift
@@ -206,6 +206,13 @@ class ArrayExtSpec : XCTestCase {
 				return xs.all { dictionary1[f.getArrow($0)] != nil && dictionary2[f.getArrow($0)] != nil && dictionary1[f.getArrow($0)] == dictionary2[f.getArrow($0)] }
 			 }
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(Array.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.first ?? ss == xs
+			}
+		}
 	}
 
 

--- a/SwiftzTests/EitherSpec.swift
+++ b/SwiftzTests/EitherSpec.swift
@@ -69,6 +69,13 @@ class EitherSpec : XCTestCase {
 			}
 		}
 
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(Either<NSError, String>.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.right! == xs
+			}
+		}
+
 		// TODO: How in hell does this typecheck?
 		// either
 		XCTAssert(Either.Left("foo").either(onLeft: { l in l+"!" }, onRight: { r in r+1 }) == "foo!")

--- a/SwiftzTests/IdentitySpec.swift
+++ b/SwiftzTests/IdentitySpec.swift
@@ -102,5 +102,13 @@ class IdentitySpec : XCTestCase {
 				return x.extend(f).extend(g) == x.extend({ g($0.extend(f)) })
 			}
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(Identity.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.runIdentity == xs
+			}
+		}
+
 	}
 }

--- a/SwiftzTests/ListSpec.swift
+++ b/SwiftzTests/ListSpec.swift
@@ -184,5 +184,12 @@ class ListSpec : XCTestCase {
 				return scanned == rig
 			}
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(List.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.head! == xs
+			}
+		}
 	}
 }

--- a/SwiftzTests/OptionalExtSpec.swift
+++ b/SwiftzTests/OptionalExtSpec.swift
@@ -115,5 +115,12 @@ class OptionalExtSpec : XCTestCase {
 			let defaultValue = 0
 			return (m.toEither(defaultValue).isLeft && m == nil) || ((m.toEither(defaultValue).isRight && m != nil))
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(Optional.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss! == xs
+			}
+		}
 	}
 }

--- a/SwiftzTests/ProxySpec.swift
+++ b/SwiftzTests/ProxySpec.swift
@@ -107,6 +107,14 @@ class ProxySpec : XCTestCase {
 				return x.extend(f).extend(g) == x.extend({ f($0.extend(g)) })
 			}
 		}
+
+		// Proxy throws away its contents, and just acts as a Proxy for a type.
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(Proxy.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.self == Proxy.pure(xs).self
+			}
+		}
 	}
 }
 

--- a/SwiftzTests/StateSpec.swift
+++ b/SwiftzTests/StateSpec.swift
@@ -27,4 +27,12 @@ struct StateOf<S, A : Arbitrary> : Arbitrary, CustomStringConvertible {
 }
 
 class StateSpec : XCTestCase {
+	func testProperties() {
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let seq = sequence(xs.map(State<String, String>.pure))
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.eval("") == xs
+			}
+		}
+	}
 }

--- a/SwiftzTests/StreamSpec.swift
+++ b/SwiftzTests/StreamSpec.swift
@@ -149,5 +149,12 @@ class StreamSpec : XCTestCase {
 				}
 			}
 		}
-	}
+
+        property("sequence occurs in order") <- forAll { (xs : [String]) in
+            let seq = sequence(xs.map({ x in Stream.pure(x).take(1) }))
+            return forAllNoShrink(Gen.pure(seq)) { ss in
+                return ss.first ?? [] == xs
+            }
+        }
+    }
 }

--- a/SwiftzTests/StringExtSpec.swift
+++ b/SwiftzTests/StringExtSpec.swift
@@ -118,5 +118,13 @@ class StringExtSpec : XCTestCase {
 
 			return Discard()
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [Character]) in
+			let seq = sequence(xs.map { String.init($0) })
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				let a = (ss.first?.characters).map { c in Array(c) }
+				return a ?? [] == xs
+			}
+		}
 	}
 }

--- a/SwiftzTests/WriterSpec.swift
+++ b/SwiftzTests/WriterSpec.swift
@@ -87,5 +87,13 @@ class WriterSpec : XCTestCase {
 				return ((m >>- f) >>- g) == (m >>- { x in f(x) >>- g })
 			}
 		}
+
+		property("sequence occurs in order") <- forAll { (xs : [String]) in
+			let ws: [Writer<String, String>] = xs.map(Writer<String, String>.pure)
+			let seq = sequence(ws)
+			return forAllNoShrink(Gen.pure(seq)) { ss in
+				return ss.runWriter.0 == xs
+			}
+		}
 	}
 }


### PR DESCRIPTION
@CodaFi Is this what you were after (re: sequence conversation on Twitter https://twitter.com/CodaFi_/status/707423595601891328)?  

sequence added for:
- `Array`
- `Either`
- `Identity`
- `List`
- `Optional`
- `Proxy`
- `State`
- `String`
- `Stream`
- `Writer`

I haven't been able to get `Reader` to type check.
