### PR TITLE
Adding type hints to curry

### DIFF
--- a/Swiftz/Curry.swift
+++ b/Swiftz/Curry.swift
@@ -12,83 +12,83 @@
 /// as opposed to an uncurried function which may take tuples.
 
 
-public func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
-
-    return { (a: A) -> B -> C in
-        { (b: B) -> C in
-
+public func curry<A, B, C>(f : (A, B) -> C) -> A -> B -> C {
+    
+    return { (a : A) -> B -> C in
+        { (b : B) -> C in
+            
             f(a, b)
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D>(f: (A, B, C) -> D) -> A -> B -> C -> D {
-
-    return { (a: A) -> B -> C -> D in
-        { (b: B) -> C -> D in
-            { (c: C) -> D in
-
+public func curry<A, B, C, D>(f : (A, B, C) -> D) -> A -> B -> C -> D {
+    
+    return { (a : A) -> B -> C -> D in
+        { (b : B) -> C -> D in
+            { (c : C) -> D in
+                
                 f(a, b, c)
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E>(f: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
-
-    return { (a: A) -> B -> C -> D -> E in
-        { (b: B) -> C -> D -> E in
-            { (c: C) -> D -> E in
-                { (d: D) -> E in
-
+public func curry<A, B, C, D, E>(f : (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
+    
+    return { (a : A) -> B -> C -> D -> E in
+        { (b : B) -> C -> D -> E in
+            { (c : C) -> D -> E in
+                { (d : D) -> E in
+                    
                     f(a, b, c, d)
                 }
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F>(f: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
-
-    return { (a: A) -> B -> C -> D -> E -> F in
-        { (b: B) -> C -> D -> E -> F in
-            { (c: C) -> D -> E -> F in
-                { (d: D) -> E -> F in
-                    { (e: E) -> F in
-
+public func curry<A, B, C, D, E, F>(f : (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
+    
+    return { (a : A) -> B -> C -> D -> E -> F in
+        { (b : B) -> C -> D -> E -> F in
+            { (c : C) -> D -> E -> F in
+                { (d : D) -> E -> F in
+                    { (e : E) -> F in
+                        
                         f(a, b, c, d, e)
                     }
                 }
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G in
-        { (b: B) -> C -> D -> E -> F -> G in
-            { (c: C) -> D -> E -> F -> G in
-                { (d: D) -> E -> F -> G in
-                    { (e: E) -> F -> G in
-                        { (ff: F) -> G in
-
+public func curry<A, B, C, D, E, F, G>(f : (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G in
+        { (b : B) -> C -> D -> E -> F -> G in
+            { (c : C) -> D -> E -> F -> G in
+                { (d : D) -> E -> F -> G in
+                    { (e : E) -> F -> G in
+                        { (ff : F) -> G in
+                            
                             f(a, b, c, d, e, ff)
                         }
                     }
@@ -96,22 +96,22 @@ public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> 
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H in
-        { (b: B) -> C -> D -> E -> F -> G -> H in
-            { (c: C) -> D -> E -> F -> G -> H in
-                { (d: D) -> E -> F -> G -> H in
-                    { (e: E) -> F -> G -> H in
-                        { (ff: F) -> G -> H in
-                            { (g: G) -> H in
-
+public func curry<A, B, C, D, E, F, G, H>(f : (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H in
+        { (b : B) -> C -> D -> E -> F -> G -> H in
+            { (c : C) -> D -> E -> F -> G -> H in
+                { (d : D) -> E -> F -> G -> H in
+                    { (e : E) -> F -> G -> H in
+                        { (ff : F) -> G -> H in
+                            { (g : G) -> H in
+                                
                                 f(a, b, c, d, e, ff, g)
                             }
                         }
@@ -120,23 +120,23 @@ public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A ->
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I in
-            { (c: C) -> D -> E -> F -> G -> H -> I in
-                { (d: D) -> E -> F -> G -> H -> I in
-                    { (e: E) -> F -> G -> H -> I in
-                        { (ff: F) -> G -> H -> I in
-                            { (g: G) -> H -> I in
-                                { (h: H) -> I in
-
+public func curry<A, B, C, D, E, F, G, H, I>(f : (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I in
+            { (c : C) -> D -> E -> F -> G -> H -> I in
+                { (d : D) -> E -> F -> G -> H -> I in
+                    { (e : E) -> F -> G -> H -> I in
+                        { (ff : F) -> G -> H -> I in
+                            { (g : G) -> H -> I in
+                                { (h : H) -> I in
+                                    
                                     f(a, b, c, d, e, ff, g, h)
                                 }
                             }
@@ -146,24 +146,24 @@ public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J in
-                { (d: D) -> E -> F -> G -> H -> I -> J in
-                    { (e: E) -> F -> G -> H -> I -> J in
-                        { (ff: F) -> G -> H -> I -> J in
-                            { (g: G) -> H -> I -> J in
-                                { (h: H) -> I -> J in
-                                    { (i: I) -> J in
-
+public func curry<A, B, C, D, E, F, G, H, I, J>(f : (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J in
+                { (d : D) -> E -> F -> G -> H -> I -> J in
+                    { (e : E) -> F -> G -> H -> I -> J in
+                        { (ff : F) -> G -> H -> I -> J in
+                            { (g : G) -> H -> I -> J in
+                                { (h : H) -> I -> J in
+                                    { (i : I) -> J in
+                                        
                                         f(a, b, c, d, e, ff, g, h, i)
                                     }
                                 }
@@ -174,25 +174,25 @@ public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K in
-                    { (e: E) -> F -> G -> H -> I -> J -> K in
-                        { (ff: F) -> G -> H -> I -> J -> K in
-                            { (g: G) -> H -> I -> J -> K in
-                                { (h: H) -> I -> J -> K in
-                                    { (i: I) -> J -> K in
-                                        { (j: J) -> K in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(f : (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K in
+                    { (e : E) -> F -> G -> H -> I -> J -> K in
+                        { (ff : F) -> G -> H -> I -> J -> K in
+                            { (g : G) -> H -> I -> J -> K in
+                                { (h : H) -> I -> J -> K in
+                                    { (i : I) -> J -> K in
+                                        { (j : J) -> K in
+                                            
                                             f(a, b, c, d, e, ff, g, h, i, j)
                                         }
                                     }
@@ -204,26 +204,26 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L in
-                            { (g: G) -> H -> I -> J -> K -> L in
-                                { (h: H) -> I -> J -> K -> L in
-                                    { (i: I) -> J -> K -> L in
-                                        { (j: J) -> K -> L in
-                                            { (k: K) -> L in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f : (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L in
+                            { (g : G) -> H -> I -> J -> K -> L in
+                                { (h : H) -> I -> J -> K -> L in
+                                    { (i : I) -> J -> K -> L in
+                                        { (j : J) -> K -> L in
+                                            { (k : K) -> L in
+                                                
                                                 f(a, b, c, d, e, ff, g, h, i, j, k)
                                             }
                                         }
@@ -236,27 +236,27 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M in
-                            { (g: G) -> H -> I -> J -> K -> L -> M in
-                                { (h: H) -> I -> J -> K -> L -> M in
-                                    { (i: I) -> J -> K -> L -> M in
-                                        { (j: J) -> K -> L -> M in
-                                            { (k: K) -> L -> M in
-                                                { (l: L) -> M in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f : (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M in
+                            { (g : G) -> H -> I -> J -> K -> L -> M in
+                                { (h : H) -> I -> J -> K -> L -> M in
+                                    { (i : I) -> J -> K -> L -> M in
+                                        { (j : J) -> K -> L -> M in
+                                            { (k : K) -> L -> M in
+                                                { (l : L) -> M in
+                                                    
                                                     f(a, b, c, d, e, ff, g, h, i, j, k, l)
                                                 }
                                             }
@@ -270,28 +270,28 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N in
-                                { (h: H) -> I -> J -> K -> L -> M -> N in
-                                    { (i: I) -> J -> K -> L -> M -> N in
-                                        { (j: J) -> K -> L -> M -> N in
-                                            { (k: K) -> L -> M -> N in
-                                                { (l: L) -> M -> N in
-                                                    { (m: M) -> N in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N in
+                                { (h : H) -> I -> J -> K -> L -> M -> N in
+                                    { (i : I) -> J -> K -> L -> M -> N in
+                                        { (j : J) -> K -> L -> M -> N in
+                                            { (k : K) -> L -> M -> N in
+                                                { (l : L) -> M -> N in
+                                                    { (m : M) -> N in
+                                                        
                                                         f(a, b, c, d, e, ff, g, h, i, j, k, l, m)
                                                     }
                                                 }
@@ -306,29 +306,29 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O in
-                                { (h: H) -> I -> J -> K -> L -> M -> N -> O in
-                                    { (i: I) -> J -> K -> L -> M -> N -> O in
-                                        { (j: J) -> K -> L -> M -> N -> O in
-                                            { (k: K) -> L -> M -> N -> O in
-                                                { (l: L) -> M -> N -> O in
-                                                    { (m: M) -> N -> O in
-                                                        { (n: N) -> O in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N -> O in
+                                { (h : H) -> I -> J -> K -> L -> M -> N -> O in
+                                    { (i : I) -> J -> K -> L -> M -> N -> O in
+                                        { (j : J) -> K -> L -> M -> N -> O in
+                                            { (k : K) -> L -> M -> N -> O in
+                                                { (l : L) -> M -> N -> O in
+                                                    { (m : M) -> N -> O in
+                                                        { (n : N) -> O in
+                                                            
                                                             f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n)
                                                         }
                                                     }
@@ -344,30 +344,30 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                                { (h: H) -> I -> J -> K -> L -> M -> N -> O -> P in
-                                    { (i: I) -> J -> K -> L -> M -> N -> O -> P in
-                                        { (j: J) -> K -> L -> M -> N -> O -> P in
-                                            { (k: K) -> L -> M -> N -> O -> P in
-                                                { (l: L) -> M -> N -> O -> P in
-                                                    { (m: M) -> N -> O -> P in
-                                                        { (n: N) -> O -> P in
-                                                            { (o: O) -> P in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                                { (h : H) -> I -> J -> K -> L -> M -> N -> O -> P in
+                                    { (i : I) -> J -> K -> L -> M -> N -> O -> P in
+                                        { (j : J) -> K -> L -> M -> N -> O -> P in
+                                            { (k : K) -> L -> M -> N -> O -> P in
+                                                { (l : L) -> M -> N -> O -> P in
+                                                    { (m : M) -> N -> O -> P in
+                                                        { (n : N) -> O -> P in
+                                                            { (o : O) -> P in
+                                                                
                                                                 f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o)
                                                             }
                                                         }
@@ -384,7 +384,7 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D
             }
         }
     }
-
+    
 }
 
 /// Converts a curried function to an uncurried function.

--- a/Swiftz/Curry.swift
+++ b/Swiftz/Curry.swift
@@ -10,60 +10,381 @@
 ///
 /// A curried function is a function that always returns another function or a value when applied
 /// as opposed to an uncurried function which may take tuples.
-public func curry<A, B, C>(f : (A, B) -> C) -> A -> B -> C {
-	return { a in { b in f(a, b) } }
+
+
+public func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
+
+    return { (a: A) -> B -> C in
+        { (b: B) -> C in
+
+            f(a, b)
+        }
+    }
+
 }
 
-public func curry<A, B, C, D>(f : (A, B, C) -> D) -> A -> B -> C -> D {
-	return { a in { b in { c in f(a, b, c) } } }
+
+
+
+public func curry<A, B, C, D>(f: (A, B, C) -> D) -> A -> B -> C -> D {
+
+    return { (a: A) -> B -> C -> D in
+        { (b: B) -> C -> D in
+            { (c: C) -> D in
+
+                f(a, b, c)
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E>(f : (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
-	return { a in { b in { c in { d in f(a, b, c, d) } } } }
+
+
+
+public func curry<A, B, C, D, E>(f: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
+
+    return { (a: A) -> B -> C -> D -> E in
+        { (b: B) -> C -> D -> E in
+            { (c: C) -> D -> E in
+                { (d: D) -> E in
+
+                    f(a, b, c, d)
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F>(f : (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
-	return { a in { b in { c in { d in { e in f(a, b, c, d, e) } } } } }
+
+
+
+public func curry<A, B, C, D, E, F>(f: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
+
+    return { (a: A) -> B -> C -> D -> E -> F in
+        { (b: B) -> C -> D -> E -> F in
+            { (c: C) -> D -> E -> F in
+                { (d: D) -> E -> F in
+                    { (e: E) -> F in
+
+                        f(a, b, c, d, e)
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G>(f : (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
-	return { a in { b in { c in { d in { e in { ff in f(a, b, c, d, e, ff) } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G in
+        { (b: B) -> C -> D -> E -> F -> G in
+            { (c: C) -> D -> E -> F -> G in
+                { (d: D) -> E -> F -> G in
+                    { (e: E) -> F -> G in
+                        { (ff: F) -> G in
+
+                            f(a, b, c, d, e, ff)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H>(f : (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
-	return { a in { b in { c in { d in { e in { ff in { g in f(a, b, c, d, e, ff, g) } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H in
+        { (b: B) -> C -> D -> E -> F -> G -> H in
+            { (c: C) -> D -> E -> F -> G -> H in
+                { (d: D) -> E -> F -> G -> H in
+                    { (e: E) -> F -> G -> H in
+                        { (ff: F) -> G -> H in
+                            { (g: G) -> H in
+
+                                f(a, b, c, d, e, ff, g)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I>(f : (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in f(a, b, c, d, e, ff, g, h) } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I in
+            { (c: C) -> D -> E -> F -> G -> H -> I in
+                { (d: D) -> E -> F -> G -> H -> I in
+                    { (e: E) -> F -> G -> H -> I in
+                        { (ff: F) -> G -> H -> I in
+                            { (g: G) -> H -> I in
+                                { (h: H) -> I in
+
+                                    f(a, b, c, d, e, ff, g, h)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J>(f : (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in f(a, b, c, d, e, ff, g, h, i) } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J in
+                { (d: D) -> E -> F -> G -> H -> I -> J in
+                    { (e: E) -> F -> G -> H -> I -> J in
+                        { (ff: F) -> G -> H -> I -> J in
+                            { (g: G) -> H -> I -> J in
+                                { (h: H) -> I -> J in
+                                    { (i: I) -> J in
+
+                                        f(a, b, c, d, e, ff, g, h, i)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K>(f : (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in f(a, b, c, d, e, ff, g, h, i, j) } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K in
+                    { (e: E) -> F -> G -> H -> I -> J -> K in
+                        { (ff: F) -> G -> H -> I -> J -> K in
+                            { (g: G) -> H -> I -> J -> K in
+                                { (h: H) -> I -> J -> K in
+                                    { (i: I) -> J -> K in
+                                        { (j: J) -> K in
+
+                                            f(a, b, c, d, e, ff, g, h, i, j)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f : (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in f(a, b, c, d, e, ff, g, h, i, j, k) } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L in
+                            { (g: G) -> H -> I -> J -> K -> L in
+                                { (h: H) -> I -> J -> K -> L in
+                                    { (i: I) -> J -> K -> L in
+                                        { (j: J) -> K -> L in
+                                            { (k: K) -> L in
+
+                                                f(a, b, c, d, e, ff, g, h, i, j, k)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f : (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in f(a, b, c, d, e, ff, g, h, i, j, k, l) } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M in
+                            { (g: G) -> H -> I -> J -> K -> L -> M in
+                                { (h: H) -> I -> J -> K -> L -> M in
+                                    { (i: I) -> J -> K -> L -> M in
+                                        { (j: J) -> K -> L -> M in
+                                            { (k: K) -> L -> M in
+                                                { (l: L) -> M in
+
+                                                    f(a, b, c, d, e, ff, g, h, i, j, k, l)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in f(a, b, c, d, e, ff, g, h, i, j, k, l, m) } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N in
+                                { (h: H) -> I -> J -> K -> L -> M -> N in
+                                    { (i: I) -> J -> K -> L -> M -> N in
+                                        { (j: J) -> K -> L -> M -> N in
+                                            { (k: K) -> L -> M -> N in
+                                                { (l: L) -> M -> N in
+                                                    { (m: M) -> N in
+
+                                                        f(a, b, c, d, e, ff, g, h, i, j, k, l, m)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in { n in f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n) } } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O in
+                                { (h: H) -> I -> J -> K -> L -> M -> N -> O in
+                                    { (i: I) -> J -> K -> L -> M -> N -> O in
+                                        { (j: J) -> K -> L -> M -> N -> O in
+                                            { (k: K) -> L -> M -> N -> O in
+                                                { (l: L) -> M -> N -> O in
+                                                    { (m: M) -> N -> O in
+                                                        { (n: N) -> O in
+
+                                                            f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n)
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in { n in { o in f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o) } } } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                                { (h: H) -> I -> J -> K -> L -> M -> N -> O -> P in
+                                    { (i: I) -> J -> K -> L -> M -> N -> O -> P in
+                                        { (j: J) -> K -> L -> M -> N -> O -> P in
+                                            { (k: K) -> L -> M -> N -> O -> P in
+                                                { (l: L) -> M -> N -> O -> P in
+                                                    { (m: M) -> N -> O -> P in
+                                                        { (n: N) -> O -> P in
+                                                            { (o: O) -> P in
+
+                                                                f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
 /// Converts a curried function to an uncurried function.


### PR DESCRIPTION
What's in this pull request?
============================

This pull request adds type hints to the curry functions.

Why merge this pull request?
============================

The swift compiler does not cope very well with generics. The more generics in the type signature, the longer it take to compile (roughly). By adding type hints to the signature, compile times can be sped up.

What's worth discussing about this pull request?
================================================

Compile times for Curry.swift (and all source files in general) can be obtained by running: 

``xcrun xcodebuild clean build OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies" | grep [1-9].[0-9]ms > culprits.txt`` (source [swift-profiling](http://irace.me/swift-profiling))

Compile times for Curry.swift __before__ this pull request are available [here](http://pastebin.com/6H7RWfc8)

__After__ this pull request Curry.swift does not even show up in the logs

What downsides are there to merging this pull request?
======================================================

Significantly more characters in Curry.swift

