### PR TITLE
Faster compile times

### DIFF
--- a/Swiftz/ArrayExt.swift
+++ b/Swiftz/ArrayExt.swift
@@ -45,15 +45,15 @@ extension Array : ApplicativeOps {
 
 	public static func liftA<B>(f : A -> B) -> [A] -> [B] {
 		typealias FAB = A -> B
-		return { a in [FAB].pure(f) <*> a }
+		return { (a : [A]) -> [B] in [FAB].pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> [A] -> [B] -> [C] {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : [A]) -> [B] -> [C] in { (b : [B]) -> [C] in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> [A] -> [B] -> [C] -> [D] {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : [A]) -> [B] -> [C] -> [D] in { (b : [B]) -> [C] -> [D] in { (c : [C]) -> [D] in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -65,15 +65,15 @@ extension Array : Monad {
 
 extension Array : MonadOps {
 	public static func liftM<B>(f : A -> B) -> [A] -> [B] {
-		return { m1 in m1 >>- { x1 in [B].pure(f(x1)) } }
+		return { (m1 : [A]) -> [B] in m1 >>- { (x1 : A) in [B].pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> [A] -> [B] -> [C] {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in [C].pure(f(x1)(x2)) } } } }
+		return { (m1 : [A]) -> [B] -> [C] in { (m2 : [B]) -> [C] in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in [C].pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> [A] -> [B] -> [C] -> [D] {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in [D].pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : [A]) -> [B] -> [C] -> [D] in { (m2 : [B]) -> [C] -> [D] in { (m3 : [C]) -> [D] in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in [D].pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 
@@ -522,9 +522,9 @@ public func concat<T>(list : [[T]]) -> [T] {
 public func sequence<A>(ms: [Array<A>]) -> Array<[A]> {
 	if ms.isEmpty { return [] }
 	
-	return ms.reduce(Array<[A]>.pure([]), combine: { n, m in
-		return n.bind { xs in
-			return m.bind { x in
+	return ms.reduce(Array<[A]>.pure([]), combine: { (n : [[A]], m : [A]) in
+		return n.bind { (xs : [A]) in
+			return m.bind { (x : A) in
 				return Array<[A]>.pure(xs + [x])
 			}
 		}

--- a/Swiftz/Curry.swift
+++ b/Swiftz/Curry.swift
@@ -12,83 +12,83 @@
 /// as opposed to an uncurried function which may take tuples.
 
 
-public func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
-
-    return { (a: A) -> B -> C in
-        { (b: B) -> C in
-
+public func curry<A, B, C>(f : (A, B) -> C) -> A -> B -> C {
+    
+    return { (a : A) -> B -> C in
+        { (b : B) -> C in
+            
             f(a, b)
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D>(f: (A, B, C) -> D) -> A -> B -> C -> D {
-
-    return { (a: A) -> B -> C -> D in
-        { (b: B) -> C -> D in
-            { (c: C) -> D in
-
+public func curry<A, B, C, D>(f : (A, B, C) -> D) -> A -> B -> C -> D {
+    
+    return { (a : A) -> B -> C -> D in
+        { (b : B) -> C -> D in
+            { (c : C) -> D in
+                
                 f(a, b, c)
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E>(f: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
-
-    return { (a: A) -> B -> C -> D -> E in
-        { (b: B) -> C -> D -> E in
-            { (c: C) -> D -> E in
-                { (d: D) -> E in
-
+public func curry<A, B, C, D, E>(f : (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
+    
+    return { (a : A) -> B -> C -> D -> E in
+        { (b : B) -> C -> D -> E in
+            { (c : C) -> D -> E in
+                { (d : D) -> E in
+                    
                     f(a, b, c, d)
                 }
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F>(f: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
-
-    return { (a: A) -> B -> C -> D -> E -> F in
-        { (b: B) -> C -> D -> E -> F in
-            { (c: C) -> D -> E -> F in
-                { (d: D) -> E -> F in
-                    { (e: E) -> F in
-
+public func curry<A, B, C, D, E, F>(f : (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
+    
+    return { (a : A) -> B -> C -> D -> E -> F in
+        { (b : B) -> C -> D -> E -> F in
+            { (c : C) -> D -> E -> F in
+                { (d : D) -> E -> F in
+                    { (e : E) -> F in
+                        
                         f(a, b, c, d, e)
                     }
                 }
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G in
-        { (b: B) -> C -> D -> E -> F -> G in
-            { (c: C) -> D -> E -> F -> G in
-                { (d: D) -> E -> F -> G in
-                    { (e: E) -> F -> G in
-                        { (ff: F) -> G in
-
+public func curry<A, B, C, D, E, F, G>(f : (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G in
+        { (b : B) -> C -> D -> E -> F -> G in
+            { (c : C) -> D -> E -> F -> G in
+                { (d : D) -> E -> F -> G in
+                    { (e : E) -> F -> G in
+                        { (ff : F) -> G in
+                            
                             f(a, b, c, d, e, ff)
                         }
                     }
@@ -96,22 +96,22 @@ public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> 
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H in
-        { (b: B) -> C -> D -> E -> F -> G -> H in
-            { (c: C) -> D -> E -> F -> G -> H in
-                { (d: D) -> E -> F -> G -> H in
-                    { (e: E) -> F -> G -> H in
-                        { (ff: F) -> G -> H in
-                            { (g: G) -> H in
-
+public func curry<A, B, C, D, E, F, G, H>(f : (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H in
+        { (b : B) -> C -> D -> E -> F -> G -> H in
+            { (c : C) -> D -> E -> F -> G -> H in
+                { (d : D) -> E -> F -> G -> H in
+                    { (e : E) -> F -> G -> H in
+                        { (ff : F) -> G -> H in
+                            { (g : G) -> H in
+                                
                                 f(a, b, c, d, e, ff, g)
                             }
                         }
@@ -120,23 +120,23 @@ public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A ->
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I in
-            { (c: C) -> D -> E -> F -> G -> H -> I in
-                { (d: D) -> E -> F -> G -> H -> I in
-                    { (e: E) -> F -> G -> H -> I in
-                        { (ff: F) -> G -> H -> I in
-                            { (g: G) -> H -> I in
-                                { (h: H) -> I in
-
+public func curry<A, B, C, D, E, F, G, H, I>(f : (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I in
+            { (c : C) -> D -> E -> F -> G -> H -> I in
+                { (d : D) -> E -> F -> G -> H -> I in
+                    { (e : E) -> F -> G -> H -> I in
+                        { (ff : F) -> G -> H -> I in
+                            { (g : G) -> H -> I in
+                                { (h : H) -> I in
+                                    
                                     f(a, b, c, d, e, ff, g, h)
                                 }
                             }
@@ -146,24 +146,24 @@ public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J in
-                { (d: D) -> E -> F -> G -> H -> I -> J in
-                    { (e: E) -> F -> G -> H -> I -> J in
-                        { (ff: F) -> G -> H -> I -> J in
-                            { (g: G) -> H -> I -> J in
-                                { (h: H) -> I -> J in
-                                    { (i: I) -> J in
-
+public func curry<A, B, C, D, E, F, G, H, I, J>(f : (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J in
+                { (d : D) -> E -> F -> G -> H -> I -> J in
+                    { (e : E) -> F -> G -> H -> I -> J in
+                        { (ff : F) -> G -> H -> I -> J in
+                            { (g : G) -> H -> I -> J in
+                                { (h : H) -> I -> J in
+                                    { (i : I) -> J in
+                                        
                                         f(a, b, c, d, e, ff, g, h, i)
                                     }
                                 }
@@ -174,25 +174,25 @@ public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K in
-                    { (e: E) -> F -> G -> H -> I -> J -> K in
-                        { (ff: F) -> G -> H -> I -> J -> K in
-                            { (g: G) -> H -> I -> J -> K in
-                                { (h: H) -> I -> J -> K in
-                                    { (i: I) -> J -> K in
-                                        { (j: J) -> K in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(f : (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K in
+                    { (e : E) -> F -> G -> H -> I -> J -> K in
+                        { (ff : F) -> G -> H -> I -> J -> K in
+                            { (g : G) -> H -> I -> J -> K in
+                                { (h : H) -> I -> J -> K in
+                                    { (i : I) -> J -> K in
+                                        { (j : J) -> K in
+                                            
                                             f(a, b, c, d, e, ff, g, h, i, j)
                                         }
                                     }
@@ -204,26 +204,26 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L in
-                            { (g: G) -> H -> I -> J -> K -> L in
-                                { (h: H) -> I -> J -> K -> L in
-                                    { (i: I) -> J -> K -> L in
-                                        { (j: J) -> K -> L in
-                                            { (k: K) -> L in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f : (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L in
+                            { (g : G) -> H -> I -> J -> K -> L in
+                                { (h : H) -> I -> J -> K -> L in
+                                    { (i : I) -> J -> K -> L in
+                                        { (j : J) -> K -> L in
+                                            { (k : K) -> L in
+                                                
                                                 f(a, b, c, d, e, ff, g, h, i, j, k)
                                             }
                                         }
@@ -236,27 +236,27 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M in
-                            { (g: G) -> H -> I -> J -> K -> L -> M in
-                                { (h: H) -> I -> J -> K -> L -> M in
-                                    { (i: I) -> J -> K -> L -> M in
-                                        { (j: J) -> K -> L -> M in
-                                            { (k: K) -> L -> M in
-                                                { (l: L) -> M in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f : (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M in
+                            { (g : G) -> H -> I -> J -> K -> L -> M in
+                                { (h : H) -> I -> J -> K -> L -> M in
+                                    { (i : I) -> J -> K -> L -> M in
+                                        { (j : J) -> K -> L -> M in
+                                            { (k : K) -> L -> M in
+                                                { (l : L) -> M in
+                                                    
                                                     f(a, b, c, d, e, ff, g, h, i, j, k, l)
                                                 }
                                             }
@@ -270,28 +270,28 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N in
-                                { (h: H) -> I -> J -> K -> L -> M -> N in
-                                    { (i: I) -> J -> K -> L -> M -> N in
-                                        { (j: J) -> K -> L -> M -> N in
-                                            { (k: K) -> L -> M -> N in
-                                                { (l: L) -> M -> N in
-                                                    { (m: M) -> N in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N in
+                                { (h : H) -> I -> J -> K -> L -> M -> N in
+                                    { (i : I) -> J -> K -> L -> M -> N in
+                                        { (j : J) -> K -> L -> M -> N in
+                                            { (k : K) -> L -> M -> N in
+                                                { (l : L) -> M -> N in
+                                                    { (m : M) -> N in
+                                                        
                                                         f(a, b, c, d, e, ff, g, h, i, j, k, l, m)
                                                     }
                                                 }
@@ -306,29 +306,29 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O in
-                                { (h: H) -> I -> J -> K -> L -> M -> N -> O in
-                                    { (i: I) -> J -> K -> L -> M -> N -> O in
-                                        { (j: J) -> K -> L -> M -> N -> O in
-                                            { (k: K) -> L -> M -> N -> O in
-                                                { (l: L) -> M -> N -> O in
-                                                    { (m: M) -> N -> O in
-                                                        { (n: N) -> O in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N -> O in
+                                { (h : H) -> I -> J -> K -> L -> M -> N -> O in
+                                    { (i : I) -> J -> K -> L -> M -> N -> O in
+                                        { (j : J) -> K -> L -> M -> N -> O in
+                                            { (k : K) -> L -> M -> N -> O in
+                                                { (l : L) -> M -> N -> O in
+                                                    { (m : M) -> N -> O in
+                                                        { (n : N) -> O in
+                                                            
                                                             f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n)
                                                         }
                                                     }
@@ -344,30 +344,30 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E
             }
         }
     }
-
+    
 }
 
 
 
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
-
-    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
-                                { (h: H) -> I -> J -> K -> L -> M -> N -> O -> P in
-                                    { (i: I) -> J -> K -> L -> M -> N -> O -> P in
-                                        { (j: J) -> K -> L -> M -> N -> O -> P in
-                                            { (k: K) -> L -> M -> N -> O -> P in
-                                                { (l: L) -> M -> N -> O -> P in
-                                                    { (m: M) -> N -> O -> P in
-                                                        { (n: N) -> O -> P in
-                                                            { (o: O) -> P in
-
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
+    
+    return { (a : A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+        { (b : B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+            { (c : C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                { (d : D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                    { (e : E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                        { (ff : F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                            { (g : G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                                { (h : H) -> I -> J -> K -> L -> M -> N -> O -> P in
+                                    { (i : I) -> J -> K -> L -> M -> N -> O -> P in
+                                        { (j : J) -> K -> L -> M -> N -> O -> P in
+                                            { (k : K) -> L -> M -> N -> O -> P in
+                                                { (l : L) -> M -> N -> O -> P in
+                                                    { (m : M) -> N -> O -> P in
+                                                        { (n : N) -> O -> P in
+                                                            { (o : O) -> P in
+                                                                
                                                                 f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o)
                                                             }
                                                         }
@@ -384,7 +384,7 @@ public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D
             }
         }
     }
-
+    
 }
 
 /// Converts a curried function to an uncurried function.

--- a/Swiftz/Curry.swift
+++ b/Swiftz/Curry.swift
@@ -10,60 +10,381 @@
 ///
 /// A curried function is a function that always returns another function or a value when applied
 /// as opposed to an uncurried function which may take tuples.
-public func curry<A, B, C>(f : (A, B) -> C) -> A -> B -> C {
-	return { a in { b in f(a, b) } }
+
+
+public func curry<A, B, C>(f: (A, B) -> C) -> A -> B -> C {
+
+    return { (a: A) -> B -> C in
+        { (b: B) -> C in
+
+            f(a, b)
+        }
+    }
+
 }
 
-public func curry<A, B, C, D>(f : (A, B, C) -> D) -> A -> B -> C -> D {
-	return { a in { b in { c in f(a, b, c) } } }
+
+
+
+public func curry<A, B, C, D>(f: (A, B, C) -> D) -> A -> B -> C -> D {
+
+    return { (a: A) -> B -> C -> D in
+        { (b: B) -> C -> D in
+            { (c: C) -> D in
+
+                f(a, b, c)
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E>(f : (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
-	return { a in { b in { c in { d in f(a, b, c, d) } } } }
+
+
+
+public func curry<A, B, C, D, E>(f: (A, B, C, D) -> E) -> A -> B -> C -> D -> E {
+
+    return { (a: A) -> B -> C -> D -> E in
+        { (b: B) -> C -> D -> E in
+            { (c: C) -> D -> E in
+                { (d: D) -> E in
+
+                    f(a, b, c, d)
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F>(f : (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
-	return { a in { b in { c in { d in { e in f(a, b, c, d, e) } } } } }
+
+
+
+public func curry<A, B, C, D, E, F>(f: (A, B, C, D, E) -> F) -> A -> B -> C -> D -> E -> F {
+
+    return { (a: A) -> B -> C -> D -> E -> F in
+        { (b: B) -> C -> D -> E -> F in
+            { (c: C) -> D -> E -> F in
+                { (d: D) -> E -> F in
+                    { (e: E) -> F in
+
+                        f(a, b, c, d, e)
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G>(f : (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
-	return { a in { b in { c in { d in { e in { ff in f(a, b, c, d, e, ff) } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G>(f: (A, B, C, D, E, F) -> G) -> A -> B -> C -> D -> E -> F -> G {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G in
+        { (b: B) -> C -> D -> E -> F -> G in
+            { (c: C) -> D -> E -> F -> G in
+                { (d: D) -> E -> F -> G in
+                    { (e: E) -> F -> G in
+                        { (ff: F) -> G in
+
+                            f(a, b, c, d, e, ff)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H>(f : (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
-	return { a in { b in { c in { d in { e in { ff in { g in f(a, b, c, d, e, ff, g) } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H>(f: (A, B, C, D, E, F, G) -> H) -> A -> B -> C -> D -> E -> F -> G -> H {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H in
+        { (b: B) -> C -> D -> E -> F -> G -> H in
+            { (c: C) -> D -> E -> F -> G -> H in
+                { (d: D) -> E -> F -> G -> H in
+                    { (e: E) -> F -> G -> H in
+                        { (ff: F) -> G -> H in
+                            { (g: G) -> H in
+
+                                f(a, b, c, d, e, ff, g)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I>(f : (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in f(a, b, c, d, e, ff, g, h) } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I>(f: (A, B, C, D, E, F, G, H) -> I) -> A -> B -> C -> D -> E -> F -> G -> H -> I {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I in
+            { (c: C) -> D -> E -> F -> G -> H -> I in
+                { (d: D) -> E -> F -> G -> H -> I in
+                    { (e: E) -> F -> G -> H -> I in
+                        { (ff: F) -> G -> H -> I in
+                            { (g: G) -> H -> I in
+                                { (h: H) -> I in
+
+                                    f(a, b, c, d, e, ff, g, h)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J>(f : (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in f(a, b, c, d, e, ff, g, h, i) } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J>(f: (A, B, C, D, E, F, G, H, I) -> J) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J in
+                { (d: D) -> E -> F -> G -> H -> I -> J in
+                    { (e: E) -> F -> G -> H -> I -> J in
+                        { (ff: F) -> G -> H -> I -> J in
+                            { (g: G) -> H -> I -> J in
+                                { (h: H) -> I -> J in
+                                    { (i: I) -> J in
+
+                                        f(a, b, c, d, e, ff, g, h, i)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K>(f : (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in f(a, b, c, d, e, ff, g, h, i, j) } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K>(f: (A, B, C, D, E, F, G, H, I, J) -> K) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K in
+                    { (e: E) -> F -> G -> H -> I -> J -> K in
+                        { (ff: F) -> G -> H -> I -> J -> K in
+                            { (g: G) -> H -> I -> J -> K in
+                                { (h: H) -> I -> J -> K in
+                                    { (i: I) -> J -> K in
+                                        { (j: J) -> K in
+
+                                            f(a, b, c, d, e, ff, g, h, i, j)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f : (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in f(a, b, c, d, e, ff, g, h, i, j, k) } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L>(f: (A, B, C, D, E, F, G, H, I, J, K) -> L) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L in
+                            { (g: G) -> H -> I -> J -> K -> L in
+                                { (h: H) -> I -> J -> K -> L in
+                                    { (i: I) -> J -> K -> L in
+                                        { (j: J) -> K -> L in
+                                            { (k: K) -> L in
+
+                                                f(a, b, c, d, e, ff, g, h, i, j, k)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f : (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in f(a, b, c, d, e, ff, g, h, i, j, k, l) } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M>(f: (A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M in
+                            { (g: G) -> H -> I -> J -> K -> L -> M in
+                                { (h: H) -> I -> J -> K -> L -> M in
+                                    { (i: I) -> J -> K -> L -> M in
+                                        { (j: J) -> K -> L -> M in
+                                            { (k: K) -> L -> M in
+                                                { (l: L) -> M in
+
+                                                    f(a, b, c, d, e, ff, g, h, i, j, k, l)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in f(a, b, c, d, e, ff, g, h, i, j, k, l, m) } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N in
+                                { (h: H) -> I -> J -> K -> L -> M -> N in
+                                    { (i: I) -> J -> K -> L -> M -> N in
+                                        { (j: J) -> K -> L -> M -> N in
+                                            { (k: K) -> L -> M -> N in
+                                                { (l: L) -> M -> N in
+                                                    { (m: M) -> N in
+
+                                                        f(a, b, c, d, e, ff, g, h, i, j, k, l, m)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in { n in f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n) } } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O in
+                                { (h: H) -> I -> J -> K -> L -> M -> N -> O in
+                                    { (i: I) -> J -> K -> L -> M -> N -> O in
+                                        { (j: J) -> K -> L -> M -> N -> O in
+                                            { (k: K) -> L -> M -> N -> O in
+                                                { (l: L) -> M -> N -> O in
+                                                    { (m: M) -> N -> O in
+                                                        { (n: N) -> O in
+
+                                                            f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n)
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
-public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
-	return { a in { b in { c in { d in { e in { ff in { g in { h in { i in { j in { k in { l in { m in { n in { o in f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o) } } } } } } } } } } } } } } }
+
+
+
+public func curry<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(f: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> A -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P {
+
+    return { (a: A) -> B -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+        { (b: B) -> C -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+            { (c: C) -> D -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                { (d: D) -> E -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                    { (e: E) -> F -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                        { (ff: F) -> G -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                            { (g: G) -> H -> I -> J -> K -> L -> M -> N -> O -> P in
+                                { (h: H) -> I -> J -> K -> L -> M -> N -> O -> P in
+                                    { (i: I) -> J -> K -> L -> M -> N -> O -> P in
+                                        { (j: J) -> K -> L -> M -> N -> O -> P in
+                                            { (k: K) -> L -> M -> N -> O -> P in
+                                                { (l: L) -> M -> N -> O -> P in
+                                                    { (m: M) -> N -> O -> P in
+                                                        { (n: N) -> O -> P in
+                                                            { (o: O) -> P in
+
+                                                                f(a, b, c, d, e, ff, g, h, i, j, k, l, m, n, o)
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 
 /// Converts a curried function to an uncurried function.

--- a/Swiftz/DictionaryExt.swift
+++ b/Swiftz/DictionaryExt.swift
@@ -44,7 +44,7 @@ extension Dictionary {
 	/// a combining function.  If the receiver does not contain a value for the given key this
 	/// function is equivalent to an `insert`.
 	public func insertWith(k : Key, v : Value, combiner : Value -> Value -> Value) -> [Key: Value] {
-		return self.insertWithKey(k, v: v, combiner: { (_, newValue, oldValue) -> Value in
+		return self.insertWithKey(k, v: v, combiner: { (_ : Key, newValue : Value, oldValue : Value) -> Value in
 			return combiner(newValue)(oldValue)
 		})
 	}

--- a/Swiftz/EitherExt.swift
+++ b/Swiftz/EitherExt.swift
@@ -62,15 +62,15 @@ extension Either : ApplicativeOps {
 	public typealias FD = Either<L, D>
 
 	public static func liftA<B>(f : A -> B) -> Either<L, A> -> Either<L, B> {
-		return { a in Either<L, A -> B>.pure(f) <*> a }
+		return { (a :  Either<L, A>) -> Either<L, B> in Either<L, A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> Either<L, A> -> Either<L, B> -> Either<L, C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : Either<L, A>) -> Either<L, B> -> Either<L, C> in { (b : Either<L, B>) -> Either<L, C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> Either<L, A> -> Either<L, B> -> Either<L, C> -> Either<L, D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : Either<L, A>) -> Either<L, B> -> Either<L, C> -> Either<L, D> in { (b : Either<L, B>) -> Either<L, C> -> Either<L, D> in { (c : Either<L, C>) -> Either<L, D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -82,15 +82,15 @@ extension Either : Monad {
 
 extension Either : MonadOps {
 	public static func liftM<B>(f : A -> B) -> Either<L, A> -> Either<L, B> {
-		return { m1 in m1 >>- { x1 in Either<L, B>.pure(f(x1)) } }
+		return { (m1 : Either<L, A>) -> Either<L, B> in m1 >>- { (x1 : A) -> Either<L, B> in Either<L, B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> Either<L, A> -> Either<L, B> -> Either<L, C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Either<L, C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : Either<L, A>) -> Either<L, B> -> Either<L, C> in { (m2 :  Either<L, B>) -> Either<L, C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in Either<L, C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> Either<L, A> -> Either<L, B> -> Either<L, C> -> Either<L, D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Either<L, D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : Either<L, A>) -> Either<L, B> -> Either<L, C> -> Either<L, D> in { (m2 : Either<L, B>) -> Either<L, C> -> Either<L, D> in { (m3 : Either<L, C>) -> Either<L, D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Either<L, D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/Identity.swift
+++ b/Swiftz/Identity.swift
@@ -62,15 +62,15 @@ extension Identity : ApplicativeOps {
 	public typealias FD = Identity<D>
 
 	public static func liftA<B>(f : A -> B) -> Identity<A> -> Identity<B> {
-		return { a in Identity<A -> B>.pure(f) <*> a }
+		return { (a : Identity<A>) -> Identity<B> in Identity<A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> Identity<A> -> Identity<B> -> Identity<C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : Identity<A>) -> Identity<B> -> Identity<C> in { (b : Identity<B>) -> Identity<C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> Identity<A> -> Identity<B> -> Identity<C> -> Identity<D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : Identity<A>) -> Identity<B> -> Identity<C> -> Identity<D> in { (b : Identity<B>) -> Identity<C> -> Identity<D> in { (c : Identity<C>) -> Identity<D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -90,15 +90,15 @@ public func >>- <A, B>(m : Identity<A>, f : A -> Identity<B>) -> Identity<B> {
 
 extension Identity : MonadOps {
 	public static func liftM<B>(f : A -> B) -> Identity<A> -> Identity<B> {
-		return { m1 in m1 >>- { x1 in Identity<B>.pure(f(x1)) } }
+		return { (m1 : Identity<A>) -> Identity<B> in m1 >>- { (x1 : A) in Identity<B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> Identity<A> -> Identity<B> -> Identity<C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Identity<C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : Identity<A>) -> Identity<B> -> Identity<C> in { (m2 : Identity<B>) -> Identity<C> in m1 >>- { (x1 : A) in m2 >>- { (x2 :B) in Identity<C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> Identity<A> -> Identity<B> -> Identity<C> -> Identity<D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Identity<D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : Identity<A>) -> Identity<B> -> Identity<C> -> Identity<D> in { (m2 : Identity<B>) -> Identity<C> -> Identity<D> in { (m3 : Identity<C>) -> Identity<D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Identity<D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/List.swift
+++ b/Swiftz/List.swift
@@ -634,15 +634,15 @@ extension List : ApplicativeOps {
 	public typealias FD = List<D>
 
 	public static func liftA<B>(f : A -> B) -> List<A> -> List<B> {
-		return { a in List<A -> B>.pure(f) <*> a }
+		return { (a : List<A>) -> List<B> in List<A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> List<A> -> List<B> -> List<C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : List<A>) -> List<B> -> List<C> in { (b : List<B>) -> List<C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> List<A> -> List<B> -> List<C> -> List<D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : List<A>) -> List<B> -> List<C> -> List<D> in { (b : List<B>) -> List<C> -> List<D> in { (c : List<C>) -> List<D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -671,15 +671,15 @@ public func >>- <A, B>(l : List<A>, f : A -> List<B>) -> List<B> {
 
 extension List : MonadOps {
 	public static func liftM<B>(f : A -> B) -> List<A> -> List<B> {
-		return { m1 in m1 >>- { x1 in List<B>.pure(f(x1)) } }
+		return { (m1 : List<A>) -> List<B> in m1 >>- { (x1 : A) in List<B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> List<A> -> List<B> -> List<C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in List<C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : List<A>) -> List<B> -> List<C> in { (m2 : List<B>) -> List<C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in List<C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> List<A> -> List<B> -> List<C> -> List<D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in List<D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : List<A>) -> List<B> -> List<C> -> List<D> in { (m2 : List<B>) -> List<C> -> List<D> in { (m3 : List<C>) -> List<D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in List<D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/NonEmptyList.swift
+++ b/Swiftz/NonEmptyList.swift
@@ -139,15 +139,15 @@ extension NonEmptyList : ApplicativeOps {
 	public typealias FD = NonEmptyList<D>
 
 	public static func liftA<B>(f : A -> B) -> NonEmptyList<A> -> NonEmptyList<B> {
-		return { a in NonEmptyList<A -> B>.pure(f) <*> a }
+		return { (a : NonEmptyList<A>) -> NonEmptyList<B> in NonEmptyList<A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> NonEmptyList<A> -> NonEmptyList<B> -> NonEmptyList<C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : NonEmptyList<A>) -> NonEmptyList<B> -> NonEmptyList<C> in { (b : NonEmptyList<B>) -> NonEmptyList<C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> NonEmptyList<A> -> NonEmptyList<B> -> NonEmptyList<C> -> NonEmptyList<D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a :  NonEmptyList<A>) -> NonEmptyList<B> -> NonEmptyList<C> -> NonEmptyList<D> in { (b : NonEmptyList<B>) -> NonEmptyList<C> -> NonEmptyList<D> in { (c : NonEmptyList<C>) -> NonEmptyList<D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -160,15 +160,15 @@ extension NonEmptyList : Monad {
 
 extension NonEmptyList : MonadOps {
 	public static func liftM<B>(f : A -> B) -> NonEmptyList<A> -> NonEmptyList<B> {
-		return { m1 in m1 >>- { x1 in NonEmptyList<B>.pure(f(x1)) } }
+		return { (m1 : NonEmptyList<A>) -> NonEmptyList<B> in m1 >>- { (x1 : A) in NonEmptyList<B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> NonEmptyList<A> -> NonEmptyList<B> -> NonEmptyList<C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in NonEmptyList<C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : NonEmptyList<A>) -> NonEmptyList<B> -> NonEmptyList<C> in { (m2 : NonEmptyList<B>) -> NonEmptyList<C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in NonEmptyList<C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> NonEmptyList<A> -> NonEmptyList<B> -> NonEmptyList<C> -> NonEmptyList<D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in NonEmptyList<D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : NonEmptyList<A>) -> NonEmptyList<B> -> NonEmptyList<C> -> NonEmptyList<D> in { (m2 : NonEmptyList<B>) -> NonEmptyList<C> -> NonEmptyList<D> in { (m3 :  NonEmptyList<C>) -> NonEmptyList<D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in NonEmptyList<D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/OptionalExt.swift
+++ b/Swiftz/OptionalExt.swift
@@ -76,15 +76,15 @@ extension Optional : ApplicativeOps {
 	public typealias FD = Optional<D>
 
 	public static func liftA<B>(f : A -> B) -> Optional<A> -> Optional<B> {
-		return { a in Optional<A -> B>.pure(f) <*> a }
+		return { (a : Optional<A>) -> Optional<B> in Optional<A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> Optional<A> -> Optional<B> -> Optional<C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : Optional<A>) -> Optional<B> -> Optional<C> in { (b : Optional<B>) -> Optional<C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> Optional<A> -> Optional<B> -> Optional<C> -> Optional<D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : Optional<A>) -> Optional<B> -> Optional<C> -> Optional<D> in { (b : Optional<B>) -> Optional<C> -> Optional<D> in { (c : Optional<C>) -> Optional<D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -96,15 +96,15 @@ extension Optional : Monad {
 
 extension Optional : MonadOps {
 	public static func liftM<B>(f : A -> B) -> Optional<A> -> Optional<B> {
-		return { m1 in m1 >>- { x1 in Optional<B>.pure(f(x1)) } }
+		return { (m1 : Optional<A>) -> Optional<B>  in m1 >>- { (x1 : A) in Optional<B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> Optional<A> -> Optional<B> -> Optional<C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Optional<C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : Optional<A>) -> Optional<B> -> Optional<C> in { (m2 : Optional<B>) -> Optional<C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in Optional<C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> Optional<A> -> Optional<B> -> Optional<C> -> Optional<D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Optional<D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : Optional<A>) -> Optional<B> -> Optional<C> -> Optional<D> in { (m2 : Optional<B>) -> Optional<C> -> Optional<D> in { (m3 : Optional<C>) -> Optional<D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Optional<D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/Reader.swift
+++ b/Swiftz/Reader.swift
@@ -88,15 +88,15 @@ extension Reader : ApplicativeOps {
     public typealias FD = Reader<R, D>
     
     public static func liftA(f : A -> B) -> Reader<R, A> -> Reader<R, B> {
-        return { a in Reader<R, A -> B>.pure(f) <*> a }
+        return { (a : Reader<R, A>) -> Reader<R, B> in Reader<R, A -> B>.pure(f) <*> a }
     }
     
     public static func liftA2(f : A -> B -> C) -> Reader<R, A> -> Reader<R, B> -> Reader<R, C> {
-        return { a in { b in f <^> a <*> b  } }
+        return { (a : Reader<R, A>) -> Reader<R, B> -> Reader<R, C> in { (b : Reader<R, B>) -> Reader<R, C> in f <^> a <*> b  } }
     }
     
     public static func liftA3(f : A -> B -> C -> D) -> Reader<R, A> -> Reader<R, B> -> Reader<R, C> -> Reader<R, D> {
-        return { a in { b in { c in f <^> a <*> b <*> c } } }
+        return { (a : Reader<R, A>) -> Reader<R, B> -> Reader<R, C> -> Reader<R, D> in { (b : Reader<R, B>) -> Reader<R, C> -> Reader<R, D> in { (c : Reader<R, C>) -> Reader<R, D> in f <^> a <*> b <*> c } } }
     }
 }
 
@@ -116,15 +116,15 @@ public func >>- <R, A, B>(r : Reader<R, A>, f : A -> Reader<R, B>) -> Reader<R, 
 
 extension Reader : MonadOps {
     public static func liftM(f : A -> B) -> Reader<R, A> -> Reader<R, B> {
-        return { m1 in m1 >>- { x1 in Reader<R, B>.pure(f(x1)) } }
+        return { (m1 : Reader<R, A>) -> Reader<R, B> in m1 >>- { (x1 : A) in Reader<R, B>.pure(f(x1)) } }
     }
     
     public static func liftM2(f : A -> B -> C) -> Reader<R, A> -> Reader<R, B> -> Reader<R, C> {
-        return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Reader<R, C>.pure(f(x1)(x2)) } } } }
+        return { (m1 : Reader<R, A>) -> Reader<R, B> -> Reader<R, C> in { (m2 : Reader<R, B>) -> Reader<R, C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in Reader<R, C>.pure(f(x1)(x2)) } } } }
     }
     
     public static func liftM3(f : A -> B -> C -> D) -> Reader<R, A> -> Reader<R, B> -> Reader<R, C> -> Reader<R, D> {
-        return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Reader<R, D>.pure(f(x1)(x2)(x3)) } } } } } }
+        return { (m1 : Reader<R, A>) -> Reader<R, B> -> Reader<R, C> -> Reader<R, D> in { (m2 : Reader<R, B>) -> Reader<R, C> -> Reader<R, D> in { (m3 : Reader<R, C>) -> Reader<R, D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Reader<R, D>.pure(f(x1)(x2)(x3)) } } } } } }
     }
 }
 

--- a/Swiftz/State.swift
+++ b/Swiftz/State.swift
@@ -100,15 +100,15 @@ extension State : ApplicativeOps {
 	public typealias FD = State<S, D>
 
 	public static func liftA<B>(f : A -> B) -> State<S, A> -> State<S, B> {
-		return { a in State<S, A -> B>.pure(f) <*> a }
+		return { (a : State<S, A>) -> State<S, B> in State<S, A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> State<S, A> -> State<S, B> -> State<S, C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : State<S, A>) -> State<S, B> -> State<S, C> in { (b : State<S, B>) -> State<S, C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> State<S, A> -> State<S, B> -> State<S, C> -> State<S, D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : State<S, A>) -> State<S, B> -> State<S, C> -> State<S, D> in { (b : State<S, B>) -> State<S, C> -> State<S, D> in { (c : State<S, C>) -> State<S, D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -127,15 +127,15 @@ public func >>- <S, A, B>(xs : State<S, A>, f : A -> State<S, B>) -> State<S, B>
 
 extension State : MonadOps {
 	public static func liftM<B>(f : A -> B) -> State<S, A> -> State<S, B> {
-		return { m1 in m1 >>- { x1 in State<S, B>.pure(f(x1)) } }
+		return { (m1 : State<S, A>) -> State<S, B> in m1 >>- { (x1 : A) in State<S, B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> State<S, A> -> State<S, B> -> State<S, C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in State<S, C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : State<S, A>) -> State<S, B> -> State<S, C> in { (m2 : State<S, B>) -> State<S, C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in State<S, C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> State<S, A> -> State<S, B> -> State<S, C> -> State<S, D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in State<S, D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : State<S, A>) -> State<S, B> -> State<S, C> -> State<S, D> in { (m2 : State<S, B>) -> State<S, C> -> State<S, D> in { (m3 : State<S, C>) -> State<S, D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in State<S, D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/Stream.swift
+++ b/Swiftz/Stream.swift
@@ -222,15 +222,15 @@ extension Stream : ApplicativeOps {
 	public typealias FD = Stream<D>
 
 	public static func liftA<B>(f : A -> B) -> Stream<A> -> Stream<B> {
-		return { a in Stream<A -> B>.pure(f) <*> a }
+		return { (a : Stream<A>) -> Stream<B> in Stream<A -> B>.pure(f) <*> a }
 	}
 
 	public static func liftA2<B, C>(f : A -> B -> C) -> Stream<A> -> Stream<B> -> Stream<C> {
-		return { a in { b in f <^> a <*> b  } }
+		return { (a : Stream<A>) -> Stream<B> -> Stream<C> in { (b : Stream<B>) -> Stream<C> in f <^> a <*> b  } }
 	}
 
 	public static func liftA3<B, C, D>(f : A -> B -> C -> D) -> Stream<A> -> Stream<B> -> Stream<C> -> Stream<D> {
-		return { a in { b in { c in f <^> a <*> b <*> c } } }
+		return { (a : Stream<A>) -> Stream<B> -> Stream<C> -> Stream<D> in { (b : Stream<B>) -> Stream<C> -> Stream<D> in { (c : Stream<C>) -> Stream<D> in f <^> a <*> b <*> c } } }
 	}
 }
 
@@ -250,15 +250,15 @@ public func >>- <A, B>(x : Stream<A>, f : A -> Stream<B>) -> Stream<B> {
 
 extension Stream : MonadOps {
 	public static func liftM<B>(f : A -> B) -> Stream<A> -> Stream<B> {
-		return { m1 in m1 >>- { x1 in Stream<B>.pure(f(x1)) } }
+		return { (m1 : Stream<A>) -> Stream<B> in m1 >>- { (x1 : A) in Stream<B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> Stream<A> -> Stream<B> -> Stream<C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Stream<C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : Stream<A>) -> Stream<B> -> Stream<C> in { (m2 : Stream<B>) -> Stream<C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in Stream<C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> Stream<A> -> Stream<B> -> Stream<C> -> Stream<D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Stream<D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : Stream<A>) -> Stream<B> -> Stream<C> -> Stream<D> in { (m2 : Stream<B>) -> Stream<C> -> Stream<D> in { (m3 : Stream<C>) -> Stream<D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Stream<D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 

--- a/Swiftz/StringExt.swift
+++ b/Swiftz/StringExt.swift
@@ -208,6 +208,6 @@ public func >>- (l : String, f : Character -> String) -> String {
 }
 
 public func sequence(ms: [String]) -> [String] {
-	return sequence(ms.map { m in Array(m.characters) }).map(String.init)
+	return sequence(ms.map { (m : String) in Array(m.characters) }).map(String.init)
 }
 

--- a/Swiftz/Writer.swift
+++ b/Swiftz/Writer.swift
@@ -128,15 +128,15 @@ public func >>- <W, A, B>(x : Writer<W, A>, f : A -> Writer<W, B>) -> Writer<W,B
 
 extension Writer : MonadOps {
 	public static func liftM<B>(f : A -> B) -> Writer<W, A> -> Writer<W, B> {
-		return { m1 in m1 >>- { x1 in Writer<W, B>.pure(f(x1)) } }
+		return { (m1 : Writer<W, A>) -> Writer<W, B> in m1 >>- { (x1 : A) in Writer<W, B>.pure(f(x1)) } }
 	}
 
 	public static func liftM2<B, C>(f : A -> B -> C) -> Writer<W, A> -> Writer<W, B> -> Writer<W, C> {
-		return { m1 in { m2 in m1 >>- { x1 in m2 >>- { x2 in Writer<W, C>.pure(f(x1)(x2)) } } } }
+		return { (m1 : Writer<W, A>) -> Writer<W, B> -> Writer<W, C> in { (m2 : Writer<W, B>) -> Writer<W, C> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in Writer<W, C>.pure(f(x1)(x2)) } } } }
 	}
 
 	public static func liftM3<B, C, D>(f : A -> B -> C -> D) -> Writer<W, A> -> Writer<W, B> -> Writer<W, C> -> Writer<W, D> {
-		return { m1 in { m2 in { m3 in m1 >>- { x1 in m2 >>- { x2 in m3 >>- { x3 in Writer<W, D>.pure(f(x1)(x2)(x3)) } } } } } }
+		return { (m1 : Writer<W, A>) -> Writer<W, B> -> Writer<W, C> -> Writer<W, D> in { (m2 : Writer<W, B>) -> Writer<W, C> -> Writer<W, D> in { (m3 : Writer<W, C>) -> Writer<W, D> in m1 >>- { (x1 : A) in m2 >>- { (x2 : B) in m3 >>- { (x3 : C) in Writer<W, D>.pure(f(x1)(x2)(x3)) } } } } } }
 	}
 }
 


### PR DESCRIPTION
What's in this pull request?
============================

This pull request adds type hits to most closures. It is a more complete version of https://github.com/typelift/Swiftz/pull/303

Why merge this pull request?
============================

This pull request shaves off at least 2.5 seconds from the compile time.

Compile time [before](http://pastebin.com/byrknAn9) and [after](http://pastebin.com/EjvMWZrS) . Notice how most of the top offenders are gone.

What's worth discussing about this pull request?
================================================

The swift compiler is not the best at inferring types so it needs a little help. There are probably more places where it could use some help (StringExt.swift for example) but I could not figure out what is confusing it.

What downsides are there to merging this pull request?
======================================================

Adds more characters here and there in the source files.

