### PR TITLE
Remove extra parenthesis when constructing List

### DIFF
--- a/Sources/List.swift
+++ b/Sources/List.swift
@@ -440,7 +440,7 @@ public struct List<Element> {
 	/// Returns a List of an infinite number of iteratations of applications of 
 	/// a function to an initial value.
 	public static func iterate(_ f : @escaping (Element) -> Element, initial : Element) -> List<Element> {
-		return List((initial, self.iterate(f, initial: f(initial))))
+		return List(initial, self.iterate(f, initial: f(initial)))
 	}
 
 	/// Cycles a finite list into an infinite list.


### PR DESCRIPTION
What's in this pull request?
============================

Removed extra parenthesis when constructing list 

Why merge this pull request?
============================
Xcode 8.2 fails to build swiftz, related #320 

What's worth discussing about this pull request?
================================================

Test case fails on Xcode 8.2 and I'm sure it's not related with this PR, but it's worth to be mentioned.

```
xctest(1097,0x7fffeb6fb3c0) malloc: *** error for object 0x106d00648: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
(lldb) 
```

<img width="1191" alt="screen shot 2016-12-28 at 00 18 22" src="https://cloud.githubusercontent.com/assets/3948217/21504635/34c869ec-cc93-11e6-9952-64aa896c5ee7.png">


What downsides are there to merging this pull request?
======================================================

- None so far(?)