### PR TITLE
[FEAT-17211]-iOS-add-securityconfig-json-on-iOS-repos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "Carthage/Checkouts/Swiftx"]
-	url = https://github.com/typelift/Swiftx.git
+	url = https://github.com/sharecare/Swiftx.git
 	path = Carthage/Checkouts/Swiftx
 [submodule "Carthage/Checkouts/FileCheck"]
 	path = Carthage/Checkouts/FileCheck
@@ -9,4 +9,4 @@
 	url = https://github.com/typelift/Operadics.git
 [submodule "Carthage/Checkouts/SwiftCheck"]
 	path = Carthage/Checkouts/SwiftCheck
-	url = https://github.com/typelift/SwiftCheck.git
+	url = https://github.com/sharecare/SwiftCheck.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: osx
       language: objective-c
-      osx_image: xcode10.2
+      osx_image: xcode11.2
       before_install:
         - git submodule update --init --recursive
       script:
@@ -13,14 +13,14 @@ matrix:
         - carthage build --no-skip-current
     - os: osx
       language: objective-c
-      osx_image: xcode10.2
+      osx_image: xcode11.2
       before_install:
         - git submodule update --init --recursive
       script:
         - set -o pipefail
         - xcodebuild test -scheme Swiftz | xcpretty -c
-        - xcodebuild build-for-testing -scheme Swiftz-iOS -destination "platform=iOS Simulator,name=iPad Pro (12.9-inch) (2nd generation)" | xcpretty -c
-        - xcodebuild test -scheme Swiftz-iOS -destination "platform=iOS Simulator,name=iPad Pro (12.9-inch) (2nd generation)" | xcpretty -c
+        - xcodebuild build-for-testing -scheme Swiftz-iOS -destination "platform=iOS Simulator,name=iPad Pro (12.9-inch) (3rd generation)" | xcpretty -c
+        - xcodebuild test -scheme Swiftz-iOS -destination "platform=iOS Simulator,name=iPad Pro (12.9-inch) (3rd generation)" | xcpretty -c
         - xcodebuild build-for-testing -scheme Swiftz-tvOS -destination 'platform=tvOS Simulator,name=Apple TV 4K (at 1080p)' | xcpretty -c
         - xcodebuild test -scheme Swiftz-tvOS -destination 'platform=tvOS Simulator,name=Apple TV 4K (at 1080p)' | xcpretty -c
     - os: linux

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,3 @@
+{
+  "settingsInheritedFrom": "Sharecare/whitesource-config@main"
+}

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
-github "typelift/Swiftx"
-github "typelift/SwiftCheck"
+github "sharecare/Swiftx" "master"
+github "sharecare/SwiftCheck" "master"
 github "typelift/Operadics"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
+github "sharecare/SwiftCheck" "c3bb2da15f0d9689eefd85394694d4f5057d5ea6"
+github "sharecare/Swiftx" "4affb6451b6981cf56c2ec1287aaee3406a5e5e0"
 github "typelift/Operadics" "0.4.0"
-github "typelift/SwiftCheck" "0.12.0"
-github "typelift/Swiftx" "0.8.0"

--- a/securityconfig.json
+++ b/securityconfig.json
@@ -1,0 +1,12 @@
+{
+  "team": "Berlin",
+  "team_owner": "Dan Eckert",
+  "team_poc": "Dimitrios Georgakopoulos",
+  "risk_assessment": {
+    "usesDeidentifiedData": false,
+    "sourcedFromPHIorPII": false,
+    "appPubliclyAccessible": true,
+    "containsPII": true,
+    "containsPHI": true
+  }
+}


### PR DESCRIPTION
What's in this pull request?
============================
Add securityconfig.json file in the root directory of the repository 
as PRs are complaining with the automated comment:

securityconfig.json file is missing.

https://arnoldmedia.jira.com/browse/FEAT-17211

# Solution
Added securityconfig.json file in the root directory that contains the project file
File securityconfig.json just needs to be added in filesystem and there is no need to add the file to project.

securityconfig.json file content:
{
  "team": "Berlin",
  "team_owner": "Dan Eckert",
  "team_poc": "Dimitrios Georgakopoulos",
  "risk_assessment": {
    "usesDeidentifiedData": false,
    "sourcedFromPHIorPII": false,
    "appPubliclyAccessible": true,
    "containsPII": true,
    "containsPHI": true
  }
}
